### PR TITLE
ci: align tf-drift OIDC auth with the main Terraform workflow

### DIFF
--- a/.github/workflows/tf-drift.yaml
+++ b/.github/workflows/tf-drift.yaml
@@ -21,6 +21,8 @@ permissions:
 
 #These environment variables are used by the terraform azure provider to setup OIDC (OpenID Connect) authentication. 
 env:
+  TF_IN_AUTOMATION: "1"
+  ARM_USE_OIDC: "true"
   ARM_CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID }}"
   ARM_SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
   ARM_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
@@ -40,6 +42,13 @@ jobs:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@v4
+
+    - name: Azure OIDC Login
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     # Install the latest version of the Terraform CLI
     - name: Setup Terraform


### PR DESCRIPTION
## Summary
- add `ARM_USE_OIDC=true` to the drift workflow
- add an explicit `azure/login@v2` step before Terraform
- align drift authentication with the working `tf-plan-apply` workflow

## Why
PR #42 fixed the Terraform working directory for `tf-drift.yaml`, but the drift workflow still used a weaker OIDC pattern than the main Terraform workflow. This follow-up makes the drift job authenticate the same way as the working plan/apply pipeline.

## Validation
- reviewed `tf-drift.yaml` against `tf-plan-apply.yaml`
- validated workflow YAML syntax with Toolbox Python
- ran `git diff --check`

Related: #43