### PR TITLE
ci: scope tf-plan-apply to Terraform changes only

### DIFF
--- a/.github/workflows/tf-plan-apply.yaml
+++ b/.github/workflows/tf-plan-apply.yaml
@@ -3,8 +3,14 @@ name: 'Terraform Plan/Apply'
 on:
   push:
     branches: [ main ]
+    paths:
+      - infra/**
+      - .github/workflows/tf-plan-apply.yaml
   pull_request:
     branches: [ main ]
+    paths:
+      - infra/**
+      - .github/workflows/tf-plan-apply.yaml
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary
- add path filters to `tf-plan-apply.yaml`
- avoid running plan/apply on unrelated workflow-only changes such as `tf-drift.yaml`

## Why
The main Terraform plan/apply workflow currently runs on every merge to `main`, even when no Terraform root or plan/apply workflow file changed. That creates noisy runs and can surface unrelated Azure OIDC failures on changes that should not trigger a full Terraform plan/apply cycle.

## Validation
- reviewed the focused workflow diff
- validated YAML syntax with Toolbox Python
- ran `git diff --check`

Related: #2