### PR TITLE
fix(terraform): scope storage diagnostics to the blob service

### DIFF
--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -59,14 +59,10 @@ resource "azurerm_log_analytics_workspace" "logs" {
 
 resource "azurerm_monitor_diagnostic_setting" "state_logs" {
   name                       = "diag-storage-state"
-  target_resource_id         = azurerm_storage_account.state.id
+  target_resource_id         = "${azurerm_storage_account.state.id}/blobServices/default"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.logs.id
 
-  # Blob service logs/metrics
-  enabled_log {
-    category = "AuditEvent"
-  }
-
+  # Azure exposes blob service read/write/delete logs on the blob service resource, not on the storage account root.
   enabled_log {
     category = "StorageRead"
   }
@@ -80,7 +76,11 @@ resource "azurerm_monitor_diagnostic_setting" "state_logs" {
   }
 
   enabled_metric {
-    category = "AllMetrics"
+    category = "Capacity"
+  }
+
+  enabled_metric {
+    category = "Transaction"
   }
 }
 


### PR DESCRIPTION
## Summary
- point the storage diagnostic setting at the blob service resource instead of the storage account root
- keep only Azure-supported blob service log categories
- replace `AllMetrics` with the exact Azure-exposed metric categories for that resource

## Why
The previous apply failed because `StorageRead` is not supported on the storage account root resource. Azure exposes `StorageRead`, `StorageWrite`, and `StorageDelete` on the `blobServices/default` resource instead.

## Validation
- queried Azure for the diagnostic categories supported by the storage account root and the blob service resource
- validated the Terraform configuration in Toolbox
- re-ran `terraform plan`
- confirmed the configuration now plans cleanly with only one diagnostic setting to create

Related: #46