### PR TITLE
docs: refresh repo status after dev bootstrap recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,19 @@ Configuration details and examples will be documented as features are implemente
 
 ## Infrastructure & Security Notes
 
-- Terraform lives under `infra/envs/<env>` and currently provisions only the `dev` remote-state resources (storage account, container, resource group). Production definitions exist but remain dormant until explicitly enabled via GitHub Actions `TF_TARGET_ENVS`.
+- Terraform lives under `infra/envs/<env>` and currently manages only the `dev` bootstrap/state resources. The live `dev` root is now state-aligned again and `terraform plan/apply` succeeds from CI.
+- The active `dev` bootstrap root currently manages:
+  - the state resource group
+  - the state storage account and `tfstate` container
+  - the Log Analytics workspace used for storage diagnostics
+  - the blob-service diagnostic setting that sends storage logs/metrics to Log Analytics
+- Production definitions exist but remain dormant until explicitly enabled via GitHub Actions `TF_TARGET_ENVS`.
 - GitHub Actions workflow `.github/workflows/tf-plan-apply.yaml` uses a matrix to run `plan/apply` per environment while scoping Terraform commands to `infra/envs/<env>` so prod is untouched unless opted in.
 - Security posture for the dev state storage account balances CI access with cost:
-  - Public network access stays enabled so GitHub Actions can reach the backend; blob/anonymous access is disabled and shared keys are off (Azure AD auth only), but the endpoint remains reachable publicly.
-  - Diagnostics go to a Log Analytics workspace with 30-day retention (current dev setting).
-  - Soft delete enabled on blob/container operations (7 days), and blob versioning remains enabled to keep tfstate recovery practical with modest dev cost impact.
+  - Public network access stays enabled so GitHub Actions can reach the backend; blob/anonymous access is disabled and shared keys are off.
+  - Azure AD auth is preferred end-to-end for the storage account, and the Terraform provider is configured to use Azure AD for storage data-plane operations.
+  - Diagnostics go to a Log Analytics workspace with 30-day retention, using the blob service resource scope that Azure Monitor actually supports for storage read/write/delete logs.
+  - Soft delete is enabled on blob/container operations (7 days), and blob versioning remains enabled to keep tfstate recovery practical with modest dev cost impact.
   - Checkov skips in dev (documented inline in `infra/envs/dev/main.tf`) due to budget/complexity:
     - CKV2_AZURE_1 (CMK), CKV_AZURE_206 (GRS replication), CKV_AZURE_59 (public network), CKV2_AZURE_33 (private endpoint).
     - CKV_AZURE_33 (queue logging), CKV2_AZURE_21 (blob read logging).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,30 +1,32 @@
 # TODO
 
-Source: 32 open GitHub issues in `maxmanus96/chatops-guard` as retrieved via GitHub MCP on 2026-03-22.
+Source: GitHub issues plus merged infra/CI work refreshed on 2026-04-16.
 
-This file is a grouped planning view of the current open issues. Some open issues are umbrella or backlog-management issues, so they are represented as planning or cleanup tasks where appropriate rather than duplicated as standalone implementation work.
+This file is a grouped planning view of the current backlog after the recent bootstrap/state recovery work. Some older issues are now delivered in merged PRs and are shown here as completion or cleanup notes rather than as active implementation tasks.
 
 ## Infrastructure
 
 ### Terraform architecture and bootstrap cleanup
 - Priority: P0
-- Short summary: Finish the Terraform foundation, reconcile the open bootstrap issues with the repo's current state, and keep the backlog epic aligned with the actual infrastructure scope.
-- Estimated effort: 1-2 days
-- Dependencies: agreement on Terraform folder architecture, issue-triage pass on stale umbrella items
+- Short summary: Keep the recovered `dev` bootstrap root stable, close stale follow-up issues, and keep the backlog aligned with the repo's now-working Terraform state.
+- Estimated effort: 0.5-1 day
+- Dependencies: one clean manual drift run on `main`, issue-triage pass on stale umbrella items
 - Tasks:
-  - [ ] #12 Decide on architecture for terraform
-  - [ ] #14 INF-01 · Remote state RG & Storage
+  - [x] #14 INF-01 · Remote state RG & Storage
+  - [ ] Close stale drift follow-up issue #46 after a clean `tf-drift` run confirms no pending changes
   - [ ] Reconcile or close #5 Draft terraform folder and do initial commit if the current repo already satisfies it
   - [ ] Keep #13 Seed backlog aligned with the infrastructure child issues that remain open
 
 ### AKS and platform services baseline
 - Priority: P1
-- Short summary: Move from state-bootstrap-only Terraform toward the first real platform components needed to host the application.
-- Estimated effort: 4-7 days
-- Dependencies: final Terraform module structure, target Azure region and sizing, environment promotion plan
+- Short summary: Move from the now-stable state bootstrap toward the first real platform components needed to host the application.
+- Estimated effort: 3-5 days
+- Dependencies: final Terraform environment-root shape, target Azure region and sizing, environment promotion plan
 - Tasks:
-  - [ ] #1 Define minimal AKS module
+  - [x] #1 Define minimal AKS module
   - [ ] #15 INF-02 · Terraform AKS module (dev)
+  - [ ] Decide the first non-bootstrap env-root shape that will eventually call `infra/modules/aks`
+  - [ ] Keep AKS design decisions explicit: subnet, egress, admin access path, private-cluster timing
   - [ ] #16 INF-03 · Event Grid + Topic
   - [ ] #17 INF-04 · Azure OpenAI (private endpoint)
   - [ ] #18 INF-05 · Key Vault + Workload Identity
@@ -41,15 +43,18 @@ This file is a grouped planning view of the current open issues. Some open issue
 
 ### CI baseline, image pipeline, and scan gates
 - Priority: P0
-- Short summary: Turn the current Terraform-focused workflows into a full delivery baseline for build, scan, publish, and registry security.
-- Estimated effort: 3-5 days
-- Dependencies: container build inputs, ACR design, app image naming/versioning strategy
+- Short summary: Finish the unfinished workflow cleanup so Terraform automation is fast, reliable, and aligned with the real repo roots before broadening CI/CD further.
+- Estimated effort: 1-2 days
+- Dependencies: final decision on whether PR `#41` should be merged as-is or superseded by smaller workflow PRs
 - Tasks:
   - [ ] #2 Add Ci&CD to the repo
-  - [ ] #31 CI-01 · Build & push images to ACR
-  - [ ] #8 Secure ACR Images when they are available
+  - [ ] Resolve draft PR #41 or replace it with smaller follow-up PRs
+  - [ ] Verify `tf-drift` end-to-end on `main`, then close #43
+  - [ ] Let the drift workflow close #46 automatically, or close it manually after verification if needed
   - [ ] #28 SEC-01 · Trivy image + IaC scan gate
   - [ ] #30 SEC-03 · SBOM generation & upload
+  - [ ] #31 CI-01 · Build & push images to ACR
+  - [ ] #8 Secure ACR Images when they are available
 
 ### Deployment and promotion workflows
 - Priority: P1
@@ -108,7 +113,7 @@ This file is a grouped planning view of the current open issues. Some open issue
 - Estimated effort: 1-2 days
 - Dependencies: stable architecture decisions, local dev story, demo path
 - Tasks:
-  - [ ] #35 DOC-01 · Mermaid architecture diagram
+  - [x] #35 DOC-01 · Mermaid architecture diagram
   - [ ] #36 DOC-02 · Quick-start with KinD mocks
 
 ### Contribution and backlog documentation

--- a/docs/terraform-architecture.md
+++ b/docs/terraform-architecture.md
@@ -11,9 +11,9 @@ The repository already has a live `dev` Terraform layout under `infra/envs/dev` 
 ## Current state
 
 - `infra/envs/dev` is the active Terraform root.
-- `infra/envs/dev` currently manages remote-state bootstrap resources.
+- `infra/envs/dev` currently manages remote-state bootstrap resources and now successfully plans/applies again after the bootstrap resources were imported into state and the storage diagnostics scope was corrected.
 - `infra/envs/prod` exists as a placeholder.
-- `infra/modules/` does not yet hold reusable modules.
+- `infra/modules/aks` now exists as the first reusable module, but it is not wired into a non-bootstrap environment root yet.
 
 ## Decision
 
@@ -66,8 +66,8 @@ Until a migration is planned, treat the current `infra/envs/dev` directory as th
 - Do not enable `prod` in CI until production roots and resources are real.
 - Do not mix bootstrap-only resources and future AKS/application resources into one growing root forever.
 
-## First safe next step
+## Current safe next step
 
-Create the first reusable module under `infra/modules/aks` without changing the current `dev` backend/bootstrap layout.
+Design the first non-bootstrap environment root that will eventually call `infra/modules/aks`, without changing the current `infra/envs/dev` backend/bootstrap layout.
 
-That gives the project a forward path toward reusable infrastructure while keeping the already-applied `dev` state stable.
+That keeps the already-applied `dev` state stable while moving AKS work from module-only scaffolding toward real environment composition.

--- a/plan.md
+++ b/plan.md
@@ -1,8 +1,15 @@
 # Infra & Workflow Plan
 
-## Terraform Environments
-- `infra/envs/dev`: provisions the remote-state RG/storage/container that back all Terraform operations. Hardened for public access, logging, and Azure AD auth; remains cost-optimized (LRS, no CMK/private endpoints).
-- `infra/envs/prod`: placeholder; backend/provider files exist but no resources are created until the environment is explicitly enabled via CI (`TF_TARGET_ENVS`).
+## Current State
+- `infra/envs/dev` is the active Terraform bootstrap root.
+- The `dev` root now successfully manages:
+  - the state resource group
+  - the state storage account and `tfstate` container
+  - the Log Analytics workspace
+  - blob-service diagnostics for the state account
+- The `dev` remote state is aligned with Azure again after importing the pre-existing bootstrap resources and correcting the storage diagnostics scope.
+- `infra/envs/prod` remains a dormant placeholder.
+- `infra/modules/aks` exists and is merged, but it is still not wired into a non-bootstrap environment root. That makes issue `#15` the real infrastructure next step, not more bootstrap repair.
 
 ## CI/CD Flow
 1. `tf-plan-apply` workflow (GitHub Actions) runs in matrix mode over `TF_TARGET_ENVS` (defaults to `["dev"]`).
@@ -12,13 +19,16 @@
    - Executes TFLint/tfsec scoped to the same directory.
    - Uploads the per-environment plan artifact and computed exit code.
 3. Apply jobs download the matching artifact, inspect the exit code, and only run `terraform apply` when changes exist and the branch is `main`.
+4. `tf-drift` is now scoped to `infra/envs/dev` and uses Azure OIDC login, but it should still be manually run once on `main` after the recent fixes so issue `#43` and the stale drift issue `#46` can be closed with confidence.
+5. `tf-unit-tests.yaml` is still legacy/root-scoped in `main`; the broader CI cleanup in draft PR `#41` remains relevant until those changes are merged or replaced.
 
 ## Security Hardening Status (Dev)
 | Control | Status | Notes |
 | --- | --- | --- |
 | Disable public/anonymous access | ⚠️ | Blob/anonymous access flags are off and soft delete enabled, but public network access remains enabled for CI. |
 | Enforce Azure AD auth only | ✅ | `shared_access_key_enabled = false`, `default_to_oauth_authentication = true`. |
-| Diagnostics to Log Analytics | ✅ | Dev LA workspace with 30-day retention (aligns with current setup; adjust if cost grows). |
+| Azure AD storage provider path | ✅ | `storage_use_azuread = true` avoids key-based storage operations in Terraform. |
+| Diagnostics to Log Analytics | ✅ | Dev LA workspace with 30-day retention; diagnostics now target the blob service scope Azure actually supports. |
 | Blob versioning | ✅ | Kept enabled on the dev state account to improve tfstate recovery; extra blob storage cost should stay modest for this small dev backend. |
 | Checkov skips (dev) | ⚠️ | CKV2_AZURE_1, CKV_AZURE_206, CKV_AZURE_59, CKV2_AZURE_33, CKV_AZURE_33, CKV2_AZURE_21 (documented inline). |
 | SAS expiration policy | ⏳ | Terraform support limited; revisit when prod environment is built. |
@@ -27,24 +37,24 @@
 | Geo-redundant replication | ⏳ | LRS kept for budget; document justification in code comment. |
 
 ## Next Steps
-1. Decide when to enable prod in CI by setting `TF_TARGET_ENVS` repo variable (e.g., `["dev","prod"]`), once prod resources are defined.
-2. Implement SAS policy, CMK, and private endpoints when moving beyond budget-friendly dev.
-3. Extend Terraform modules beyond state bootstrap (e.g., AKS module) when infrastructure scope broadens.
-4. If Log Analytics cost is high in dev, consider lowering retention, switching diagnostics to a storage account, or making diagnostics optional per environment.
+1. Manually dispatch `tf-drift` on `main` once and confirm it runs clean; then close issue `#43` and the stale drift issue `#46` if the workflow also closes them.
+2. Decide whether to merge or supersede draft PR `#41`, because the current `main` branch still lacks its `tf-unit-tests` modernization and guarded `tf-destroy` workflow.
+3. Continue issue `#15` by designing the first non-bootstrap environment wiring for AKS. Do not apply AKS in `dev` yet; decide the env-root shape first.
+4. Only after the CI gap and AKS env-root decision are settled, revisit dev hardening upgrades such as SAS policy, CMK, private endpoints, or GRS.
 
-## ROI Priority Order (2026-03-26)
+## ROI Priority Order (2026-04-16)
 
 ### Recommendation
-- Merge the first infra PR if checks are green and there are no unresolved review comments.
-- Continue the next ticket from a clean mainline instead of stacking more infra work on the same PR.
-- If the next ticket is Terraform AKS, work on the module skeleton only. Do not apply a dev AKS cluster yet.
-- Treat `#2`, `#5`, and `#13` as umbrella or cleanup issues; do not let them outrank the more concrete scoped issues.
+- Treat bootstrap/state recovery as done unless drift or apply proves otherwise.
+- Finish the unfinished CI cleanup before opening new workflow branches.
+- Keep AKS work on issue `#15` focused on environment wiring and explicit design decisions, not on provisioning a real cluster yet.
+- Use umbrella issues such as `#2` and `#13` for tracking only; do not let them outrank the scoped implementation work.
 
 ### Highest ROI / lowest direct cloud cost
-1. Lock the Terraform shape and close the bootstrap/docs gap:
-   - `#12`, `#14`, `#35`, `#36`
-2. Start reusable Terraform without provisioning more Azure resources:
-   - `#1`, `#15`
+1. Close the CI and workflow hygiene gap:
+   - PR `#41`, issue `#43`, issue `#46`
+2. Continue reusable Terraform without provisioning more Azure resources:
+   - `#15`
 3. Improve supply-chain and project automation with mostly engineering time, not cloud spend:
    - `#28`, `#30`, `#38`, `#39`
 
@@ -61,8 +71,7 @@
    - `#23`, `#25`, `#26`, `#37`
 
 ## Suggested Sequence
-1. Merge the current green infra PR.
-2. Finish architecture/bootstrap follow-up work and reconcile legacy umbrella issues.
-3. Create `infra/modules/aks` as a module skeleton only, without applying AKS in dev.
-4. Tighten docs and quick-start guidance so the repo is easier to evaluate and continue from.
-5. Then return to CI/CD and the smallest application skeleton work.
+1. Verify and finish the remaining workflow cleanup (`#41`, `#43`, `#46`).
+2. Reconcile issue hygiene for delivered infra work (`#1`, `#14`) vs still-active follow-up work (`#15`).
+3. Resume AKS design from the environment-wiring side instead of adding more skeleton-only hardening.
+4. Then return to the smallest application skeleton work.


### PR DESCRIPTION
## Summary
- refresh the repo status docs after the successful `dev` bootstrap/state recovery work
- update the plan and TODO views so they stop pointing at already-fixed bootstrap problems
- make the real next steps explicit: finish the remaining CI cleanup, verify drift end-to-end, then continue issue `#15`

## What changed
- `README.md`
  - clarify that the live `dev` bootstrap root is state-aligned again and CI `plan/apply` succeeds
  - document Azure AD storage-provider usage, blob-service diagnostics scope, and versioning posture
- `plan.md`
  - replace stale pre-merge guidance with the current reality after PRs `#47` and `#48`
  - set next steps to `tf-drift` verification, PR `#41` resolution, and AKS env-root design
- `docs/TODO.md`
  - mark delivered items such as `#14` and `#1`
  - move active work toward `#15`, `#41`, `#43`, and `#46`
- `docs/terraform-architecture.md`
  - update current state and safe next step now that the AKS module exists and bootstrap recovery is complete

## Why
The repo docs were still describing pre-recovery status: PR `#40` looked unmerged, bootstrap/state looked unfinished, and the next steps still pointed at problems that are already fixed.

## Validation
- `git diff --check -- README.md plan.md docs/TODO.md docs/terraform-architecture.md`

Related to: #15, #43, #46