### PR TITLE
feat(terraform): add staged dev-platform root for AKS rollout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+*tfplan*
 
 # Terraform child modules may be initialized locally for validation, but provider lock files belong in root modules.
 infra/modules/**/.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Configuration details and examples will be documented as features are implemente
   - the state storage account and `tfstate` container
   - the Log Analytics workspace used for storage diagnostics
   - the blob-service diagnostic setting that sends storage logs/metrics to Log Analytics
-- `infra/modules/aks` now exists as the first reusable platform module, and `infra/envs/dev-platform` is the first thin non-bootstrap root that composes it. That root now has its own backend/state and has been safely applied once to create only `rg-chatops-guard-platform-dev`, while AKS stays explicitly disabled by default via `enable_aks = false` and is documented with `infra/envs/dev-platform/terraform.tfvars.example`.
+- `infra/modules/aks` now exists as the first reusable platform module, and `infra/envs/dev-platform` is the first thin non-bootstrap root that composes it. That root now has its own backend/state, has safely applied `rg-chatops-guard-platform-dev` plus a minimal VNet/subnet foundation, and can produce a real `enable_aks = true` plan while AKS still stays explicitly gated by default.
 - Production definitions exist but remain dormant until explicitly enabled via GitHub Actions `TF_TARGET_ENVS`.
 - GitHub Actions workflow `.github/workflows/tf-plan-apply.yaml` uses a matrix to run `plan/apply` per environment while scoping Terraform commands to `infra/envs/<env>` so prod is untouched unless opted in.
 - Security posture for the dev state storage account balances CI access with cost:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ Configuration details and examples will be documented as features are implemente
   - the state storage account and `tfstate` container
   - the Log Analytics workspace used for storage diagnostics
   - the blob-service diagnostic setting that sends storage logs/metrics to Log Analytics
-- `infra/modules/aks` now exists as the first reusable platform module, and `infra/envs/dev-platform` is the first thin non-bootstrap root that composes it. That root now has its own backend/state, has safely applied `rg-chatops-guard-platform-dev` plus a minimal VNet/subnet foundation, and can produce a real `enable_aks = true` plan while AKS still stays explicitly gated by default.
+- `infra/modules/aks` now exists as the first reusable platform module, and `infra/envs/dev-platform` is the first thin non-bootstrap root that composes it. That root now has its own backend/state, has safely applied `rg-chatops-guard-platform-dev` plus a minimal VNet/subnet foundation, and can produce a real `enable_aks = true` plan while AKS still stays explicitly gated by default. When AKS is enabled there, `api_server_authorized_ip_ranges` must also be set so the first demo cluster does not leave its public API open unintentionally.
+- The first AKS rollout path is intentionally local-first: use an untracked `infra/envs/dev-platform/terraform.tfvars` for `enable_aks = true` and your local `/32` admin IP. `dev-platform` is not in GitHub `tf-plan-apply` yet, by design.
+- The first demo AKS cluster keeps local accounts enabled for now because disabling them on Kubernetes 1.25+ requires managed AAD integration. That hardening step is now tracked in issue `#52` until the Entra ID/RBAC slice is introduced.
 - Production definitions exist but remain dormant until explicitly enabled via GitHub Actions `TF_TARGET_ENVS`.
 - GitHub Actions workflow `.github/workflows/tf-plan-apply.yaml` uses a matrix to run `plan/apply` per environment while scoping Terraform commands to `infra/envs/<env>` so prod is untouched unless opted in.
 - Security posture for the dev state storage account balances CI access with cost:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Configuration details and examples will be documented as features are implemente
   - the state storage account and `tfstate` container
   - the Log Analytics workspace used for storage diagnostics
   - the blob-service diagnostic setting that sends storage logs/metrics to Log Analytics
-- `infra/modules/aks` now exists as the first reusable platform module, but it is still not wired into a non-bootstrap environment root and does not create a real AKS cluster yet.
+- `infra/modules/aks` now exists as the first reusable platform module, and `infra/envs/dev-platform` is the first thin non-bootstrap root that composes it. That root now has its own backend/state and has been safely applied once to create only `rg-chatops-guard-platform-dev`, while AKS stays explicitly disabled by default via `enable_aks = false` and is documented with `infra/envs/dev-platform/terraform.tfvars.example`.
 - Production definitions exist but remain dormant until explicitly enabled via GitHub Actions `TF_TARGET_ENVS`.
 - GitHub Actions workflow `.github/workflows/tf-plan-apply.yaml` uses a matrix to run `plan/apply` per environment while scoping Terraform commands to `infra/envs/<env>` so prod is untouched unless opted in.
 - Security posture for the dev state storage account balances CI access with cost:

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -35,8 +35,12 @@ This file is a grouped planning view of the current backlog after the recent boo
   - [x] Replace the raw Log Analytics workspace ID input with a workspace lookup by name and resource group
   - [x] Add `terraform.tfvars.example` so the safe-first-apply path and first AKS-enable path are both visible
   - [x] Produce the first real `enable_aks = true` AKS plan successfully
-  - [ ] Decide whether the first real AKS apply belongs in PR #51 or the immediate follow-up PR
-  - [ ] Set `api_server_authorized_ip_ranges` for the demo cluster before the first apply if API restriction is desired from day one
+  - [x] Keep the first AKS rollout local-first with an untracked `infra/envs/dev-platform/terraform.tfvars`
+  - [x] Set `api_server_authorized_ip_ranges` locally before the first apply; `enable_aks = true` now requires it
+  - [x] Keep `local_account_disabled = false` for the first demo cluster until managed AAD integration exists
+  - [x] Prove the first local `enable_aks = true` apply from `infra/envs/dev-platform`
+  - [ ] Add `dev-platform` to GitHub validation in a follow-up CI PR after the local AKS rollout is proven
+  - [ ] #52 INF-07 · AKS managed Entra ID integration and disable local accounts
   - [ ] Keep AKS design decisions explicit: egress, admin access path, private-cluster timing
   - [ ] #16 INF-03 · Event Grid + Topic
   - [ ] #17 INF-04 · Azure OpenAI (private endpoint)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -22,18 +22,22 @@ This file is a grouped planning view of the current backlog after the recent boo
 - Priority: P1
 - Short summary: Keep bootstrap separate from platform composition while turning the merged AKS module into a staged environment-root path.
 - Estimated effort: 3-5 days
-- Dependencies: final environment-root wiring for network and monitoring inputs, target Azure region and sizing, environment promotion plan
+- Dependencies: final AKS demo-risk decision, target Azure region and sizing, environment promotion plan
 - Tasks:
   - [x] #1 Define minimal AKS module
   - [x] #15 INF-02 · Terraform AKS module (dev) closed by PR #40
+  - [x] #50 INF-06 · First dev-platform Terraform root for staged AKS rollout
   - [x] Scaffold `infra/envs/dev-platform` as the first non-bootstrap environment root for AKS composition
   - [x] Add `enable_aks = false` so the first safe apply can create only the platform resource group
   - [x] Apply `infra/envs/dev-platform` once to create `rg-chatops-guard-platform-dev` without creating AKS
-  - [x] Keep `vnet_subnet_id` and `log_analytics_workspace_id` as explicit injected inputs for now
+  - [x] Add `infra/modules/network` and apply the minimal dev VNet/subnet foundation
+  - [x] Replace the raw subnet input with `module.network.aks_node_subnet_id`
+  - [x] Replace the raw Log Analytics workspace ID input with a workspace lookup by name and resource group
   - [x] Add `terraform.tfvars.example` so the safe-first-apply path and first AKS-enable path are both visible
-  - [ ] Fill in the real `vnet_subnet_id` and `log_analytics_workspace_id` values before the first `enable_aks = true` apply
-  - [ ] Decide later whether those dependencies should stay injected inputs or move behind sibling modules/data sources
-  - [ ] Keep AKS design decisions explicit: subnet, egress, admin access path, private-cluster timing
+  - [x] Produce the first real `enable_aks = true` AKS plan successfully
+  - [ ] Decide whether the first real AKS apply belongs in PR #51 or the immediate follow-up PR
+  - [ ] Set `api_server_authorized_ip_ranges` for the demo cluster before the first apply if API restriction is desired from day one
+  - [ ] Keep AKS design decisions explicit: egress, admin access path, private-cluster timing
   - [ ] #16 INF-03 · Event Grid + Topic
   - [ ] #17 INF-04 · Azure OpenAI (private endpoint)
   - [ ] #18 INF-05 · Key Vault + Workload Identity

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -20,13 +20,19 @@ This file is a grouped planning view of the current backlog after the recent boo
 
 ### AKS and platform services baseline
 - Priority: P1
-- Short summary: Move from the now-stable state bootstrap toward the first real platform components needed to host the application.
+- Short summary: Keep bootstrap separate from platform composition while turning the merged AKS module into a staged environment-root path.
 - Estimated effort: 3-5 days
-- Dependencies: final Terraform environment-root shape, target Azure region and sizing, environment promotion plan
+- Dependencies: final environment-root wiring for network and monitoring inputs, target Azure region and sizing, environment promotion plan
 - Tasks:
   - [x] #1 Define minimal AKS module
-  - [ ] #15 INF-02 · Terraform AKS module (dev)
-  - [ ] Decide the first non-bootstrap env-root shape that will eventually call `infra/modules/aks`
+  - [x] #15 INF-02 · Terraform AKS module (dev) closed by PR #40
+  - [x] Scaffold `infra/envs/dev-platform` as the first non-bootstrap environment root for AKS composition
+  - [x] Add `enable_aks = false` so the first safe apply can create only the platform resource group
+  - [x] Apply `infra/envs/dev-platform` once to create `rg-chatops-guard-platform-dev` without creating AKS
+  - [x] Keep `vnet_subnet_id` and `log_analytics_workspace_id` as explicit injected inputs for now
+  - [x] Add `terraform.tfvars.example` so the safe-first-apply path and first AKS-enable path are both visible
+  - [ ] Fill in the real `vnet_subnet_id` and `log_analytics_workspace_id` values before the first `enable_aks = true` apply
+  - [ ] Decide later whether those dependencies should stay injected inputs or move behind sibling modules/data sources
   - [ ] Keep AKS design decisions explicit: subnet, egress, admin access path, private-cluster timing
   - [ ] #16 INF-03 · Event Grid + Topic
   - [ ] #17 INF-04 · Azure OpenAI (private endpoint)

--- a/docs/terraform-architecture.md
+++ b/docs/terraform-architecture.md
@@ -17,6 +17,9 @@ The repository already has a live `dev` Terraform layout under `infra/envs/dev` 
 - `infra/modules/network` now exists as a sibling module for the minimal dev VNet/subnet foundation.
 - `infra/envs/dev-platform` now exists as the first thin non-bootstrap environment root that composes both modules without changing the live bootstrap root.
 - That root now has its own backend/state, has been safely applied for the platform resource group and network foundation, and can produce a real `enable_aks = true` cluster plan while `enable_aks = false` still keeps cluster creation off by default.
+- When `enable_aks = true`, the root now also requires explicit `api_server_authorized_ip_ranges` so the first public dev cluster does not accidentally expose its API to the world.
+- The first AKS rollout path is intentionally local-first: a local untracked `infra/envs/dev-platform/terraform.tfvars` can enable AKS and carry the operator's `/32` admin IP without turning that machine-specific data into a repo default.
+- The first demo AKS rollout keeps local accounts enabled for now. Disabling them is deferred into issue `#52` because AKS rejects that setting on Kubernetes 1.25+ clusters without managed AAD / Entra ID integration.
 
 ## Decision
 
@@ -83,6 +86,8 @@ Why the name is explicit right now:
 
 The network side is now handled by `infra/modules/network`, and the monitoring side is resolved through an explicit Log Analytics workspace lookup from the existing bootstrap resources.
 
-That means the next real decision is no longer wiring but rollout intent: whether the first `enable_aks = true` apply belongs in this PR or in the immediate follow-up once demo-time API access restrictions are set.
+That local rollout proof is now done. The next real decisions are:
+- add `infra/envs/dev-platform` to GitHub validation as a focused follow-up CI slice
+- handle managed Entra ID integration in issue `#52`
 
 That keeps the already-applied `dev` state stable while moving AKS work from module-only scaffolding toward real environment composition.

--- a/docs/terraform-architecture.md
+++ b/docs/terraform-architecture.md
@@ -14,8 +14,9 @@ The repository already has a live `dev` Terraform layout under `infra/envs/dev` 
 - `infra/envs/dev` currently manages remote-state bootstrap resources and now successfully plans/applies again after the bootstrap resources were imported into state and the storage diagnostics scope was corrected.
 - `infra/envs/prod` exists as a placeholder.
 - `infra/modules/aks` now exists as the first reusable module, delivered by issue `#1` and PR `#40`.
-- `infra/envs/dev-platform` now exists as the first thin non-bootstrap environment root that composes the AKS module without changing the live bootstrap root.
-- That root now has its own backend/state and has been safely applied once to create only the platform resource group while `enable_aks = false` keeps cluster creation off by default.
+- `infra/modules/network` now exists as a sibling module for the minimal dev VNet/subnet foundation.
+- `infra/envs/dev-platform` now exists as the first thin non-bootstrap environment root that composes both modules without changing the live bootstrap root.
+- That root now has its own backend/state, has been safely applied for the platform resource group and network foundation, and can produce a real `enable_aks = true` cluster plan while `enable_aks = false` still keeps cluster creation off by default.
 
 ## Decision
 
@@ -29,6 +30,7 @@ infra/
       prod/
   modules/
     aks/
+    network/
     acr/
     event-grid/
     key-vault/
@@ -79,8 +81,8 @@ Why the name is explicit right now:
 
 ## Next safe step after that scaffold
 
-Keep the first real `dev-platform` rollout on explicit injected inputs for the node-subnet ID and Log Analytics workspace ID. The repo now documents that contract in `infra/envs/dev-platform/terraform.tfvars.example`.
+The network side is now handled by `infra/modules/network`, and the monitoring side is resolved through an explicit Log Analytics workspace lookup from the existing bootstrap resources.
 
-Then fill in the real values before any first `enable_aks = true` AKS plan/apply.
+That means the next real decision is no longer wiring but rollout intent: whether the first `enable_aks = true` apply belongs in this PR or in the immediate follow-up once demo-time API access restrictions are set.
 
 That keeps the already-applied `dev` state stable while moving AKS work from module-only scaffolding toward real environment composition.

--- a/docs/terraform-architecture.md
+++ b/docs/terraform-architecture.md
@@ -13,7 +13,9 @@ The repository already has a live `dev` Terraform layout under `infra/envs/dev` 
 - `infra/envs/dev` is the active Terraform root.
 - `infra/envs/dev` currently manages remote-state bootstrap resources and now successfully plans/applies again after the bootstrap resources were imported into state and the storage diagnostics scope was corrected.
 - `infra/envs/prod` exists as a placeholder.
-- `infra/modules/aks` now exists as the first reusable module, but it is not wired into a non-bootstrap environment root yet.
+- `infra/modules/aks` now exists as the first reusable module, delivered by issue `#1` and PR `#40`.
+- `infra/envs/dev-platform` now exists as the first thin non-bootstrap environment root that composes the AKS module without changing the live bootstrap root.
+- That root now has its own backend/state and has been safely applied once to create only the platform resource group while `enable_aks = false` keeps cluster creation off by default.
 
 ## Decision
 
@@ -68,6 +70,17 @@ Until a migration is planned, treat the current `infra/envs/dev` directory as th
 
 ## Current safe next step
 
-Design the first non-bootstrap environment root that will eventually call `infra/modules/aks`, without changing the current `infra/envs/dev` backend/bootstrap layout.
+That step is now done: `infra/envs/dev-platform` is the first thin non-bootstrap environment root that composes the AKS module while leaving `infra/envs/dev` bootstrap-only.
+
+Why the name is explicit right now:
+
+- `infra/envs/dev` is still the live bootstrap root
+- `infra/envs/dev-platform` makes the platform boundary visible until there is an explicit bootstrap migration plan
+
+## Next safe step after that scaffold
+
+Keep the first real `dev-platform` rollout on explicit injected inputs for the node-subnet ID and Log Analytics workspace ID. The repo now documents that contract in `infra/envs/dev-platform/terraform.tfvars.example`.
+
+Then fill in the real values before any first `enable_aks = true` AKS plan/apply.
 
 That keeps the already-applied `dev` state stable while moving AKS work from module-only scaffolding toward real environment composition.

--- a/infra/envs/dev-platform/.terraform.lock.hcl
+++ b/infra/envs/dev-platform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.68.0"
+  constraints = "~> 4.39"
+  hashes = [
+    "h1:nHpvuCg9eexZFeRmH1OCmllvgaLgX0mSApo/uZ6B0Y4=",
+    "zh:08865385ea0c84d208d6ca16644336466e836d56c3639ac369210dbcb9187fb1",
+    "zh:0a42695cb13eefe955ad183e560a8bd35cfb714834525fd5b3749d66d347a562",
+    "zh:195b77405fc54bfc21aa0b20f63f34ad0362fe856cdade7db5a11cd16ae53d4d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:996d0baa2d8462c55631f7c7982b8786ef7f632e3b401ebb596339178b7941a0",
+    "zh:99d43f9edfe225ade0069bd53634c7ae9208297c65db50f26ba5a31c1df3c9c3",
+    "zh:9e7a9d4dee8fd53dba6b0adf5485400f07ee0c603a079000e6246ca69e7ecfd4",
+    "zh:a59ce7d80bc451f03c88afd97cd5effad3079cea4974f0350527abec805e1fd4",
+    "zh:a9a6772178c1e40203c48a56ae611fb09625d1db64357c04ead34b60249188a3",
+    "zh:bdf0f56843cb67174cb32a2956701ac1b68bbdc5c311c62900de72f247d3d42d",
+    "zh:d02a5cd102ef3bfd98373b4d5e711b2f2d403595f4606fc29a897167da36edba",
+    "zh:dbbbb5a9da53e4a71b0b996c3abb9fe3f7422e07f50f5cf2f6eb56fa4ddd66e1",
+  ]
+}

--- a/infra/envs/dev-platform/backend.tf
+++ b/infra/envs/dev-platform/backend.tf
@@ -1,0 +1,12 @@
+terraform {
+  # Pin the Terraform version for reproducible deployments.
+  required_version = ">= 1.5.0"
+
+  backend "azurerm" {
+    resource_group_name  = "rg-chatops-guard-state"
+    storage_account_name = "chatopsstateguard01"
+    container_name       = "tfstate"
+    key                  = "infra-dev-platform.tfstate"
+    use_azuread_auth     = true
+  }
+}

--- a/infra/envs/dev-platform/main.tf
+++ b/infra/envs/dev-platform/main.tf
@@ -52,6 +52,9 @@ module "aks" {
   node_vm_size       = var.node_vm_size
   vnet_subnet_id     = module.network.aks_node_subnet_id
 
+  # Keep local accounts enabled for the first demo cluster. Disabling them now
+  # would require managed AAD integration, which is a later hardening slice.
+  local_account_disabled          = false
   private_cluster_enabled         = false
   automatic_upgrade_channel       = "patch"
   network_plugin                  = "azure"

--- a/infra/envs/dev-platform/main.tf
+++ b/infra/envs/dev-platform/main.tf
@@ -1,0 +1,50 @@
+locals {
+  tags = merge(
+    {
+      environment = "dev"
+      stack       = "platform"
+      managed_by  = "terraform"
+    },
+    var.tags
+  )
+}
+
+resource "azurerm_resource_group" "platform" {
+  name     = var.platform_resource_group_name
+  location = var.location
+  tags     = local.tags
+}
+
+# This root is intentionally thin. It owns the environment-level composition
+# and passes shared dependencies in as inputs instead of reaching back into the
+# live bootstrap root.
+#
+# Keep AKS behind an explicit feature flag so the first safe apply can create
+# only the platform resource group before network and monitoring dependencies
+# are fully wired.
+module "aks" {
+  count  = var.enable_aks ? 1 : 0
+  source = "../../modules/aks"
+
+  cluster_name        = var.cluster_name
+  resource_group_name = azurerm_resource_group.platform.name
+  location            = azurerm_resource_group.platform.location
+  dns_prefix          = var.dns_prefix
+
+  kubernetes_version = var.kubernetes_version
+  node_count         = var.node_count
+  node_vm_size       = var.node_vm_size
+  vnet_subnet_id     = var.vnet_subnet_id
+
+  private_cluster_enabled         = false
+  automatic_upgrade_channel       = "patch"
+  network_plugin                  = "azure"
+  network_plugin_mode             = "overlay"
+  network_policy                  = "cilium"
+  network_data_plane              = "cilium"
+  outbound_type                   = "loadBalancer"
+  api_server_authorized_ip_ranges = var.api_server_authorized_ip_ranges
+
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+  tags                       = local.tags
+}

--- a/infra/envs/dev-platform/main.tf
+++ b/infra/envs/dev-platform/main.tf
@@ -15,13 +15,29 @@ resource "azurerm_resource_group" "platform" {
   tags     = local.tags
 }
 
+module "network" {
+  source = "../../modules/network"
+
+  resource_group_name      = azurerm_resource_group.platform.name
+  location                 = azurerm_resource_group.platform.location
+  vnet_name                = var.vnet_name
+  vnet_address_space       = var.vnet_address_space
+  aks_node_subnet_name     = var.aks_node_subnet_name
+  aks_node_subnet_prefixes = var.aks_node_subnet_prefixes
+  tags                     = local.tags
+}
+
+data "azurerm_log_analytics_workspace" "logs" {
+  name                = var.log_analytics_workspace_name
+  resource_group_name = var.log_analytics_resource_group_name
+}
+
 # This root is intentionally thin. It owns the environment-level composition
 # and passes shared dependencies in as inputs instead of reaching back into the
 # live bootstrap root.
 #
 # Keep AKS behind an explicit feature flag so the first safe apply can create
-# only the platform resource group before network and monitoring dependencies
-# are fully wired.
+# only the platform resource group and network foundation before the cluster is enabled.
 module "aks" {
   count  = var.enable_aks ? 1 : 0
   source = "../../modules/aks"
@@ -34,7 +50,7 @@ module "aks" {
   kubernetes_version = var.kubernetes_version
   node_count         = var.node_count
   node_vm_size       = var.node_vm_size
-  vnet_subnet_id     = var.vnet_subnet_id
+  vnet_subnet_id     = module.network.aks_node_subnet_id
 
   private_cluster_enabled         = false
   automatic_upgrade_channel       = "patch"
@@ -45,6 +61,6 @@ module "aks" {
   outbound_type                   = "loadBalancer"
   api_server_authorized_ip_ranges = var.api_server_authorized_ip_ranges
 
-  log_analytics_workspace_id = var.log_analytics_workspace_id
+  log_analytics_workspace_id = data.azurerm_log_analytics_workspace.logs.id
   tags                       = local.tags
 }

--- a/infra/envs/dev-platform/outputs.tf
+++ b/infra/envs/dev-platform/outputs.tf
@@ -1,0 +1,29 @@
+output "platform_resource_group_name" {
+  description = "Resource group used by the dev platform root."
+  value       = azurerm_resource_group.platform.name
+}
+
+output "aks_id" {
+  description = "AKS cluster resource ID."
+  value       = var.enable_aks ? module.aks[0].id : null
+}
+
+output "aks_name" {
+  description = "AKS cluster name."
+  value       = var.enable_aks ? module.aks[0].name : null
+}
+
+output "aks_fqdn" {
+  description = "AKS API server FQDN."
+  value       = var.enable_aks ? module.aks[0].fqdn : null
+}
+
+output "aks_node_resource_group" {
+  description = "Managed resource group created by AKS."
+  value       = var.enable_aks ? module.aks[0].node_resource_group : null
+}
+
+output "kubelet_identity_object_id" {
+  description = "Object ID of the kubelet identity for later ACR or Key Vault access rules."
+  value       = var.enable_aks ? module.aks[0].kubelet_identity_object_id : null
+}

--- a/infra/envs/dev-platform/outputs.tf
+++ b/infra/envs/dev-platform/outputs.tf
@@ -3,6 +3,31 @@ output "platform_resource_group_name" {
   value       = azurerm_resource_group.platform.name
 }
 
+output "vnet_id" {
+  description = "Virtual network resource ID for the dev platform root."
+  value       = module.network.vnet_id
+}
+
+output "vnet_name" {
+  description = "Virtual network name for the dev platform root."
+  value       = module.network.vnet_name
+}
+
+output "aks_node_subnet_id" {
+  description = "AKS node subnet resource ID."
+  value       = module.network.aks_node_subnet_id
+}
+
+output "aks_node_subnet_name" {
+  description = "AKS node subnet name."
+  value       = module.network.aks_node_subnet_name
+}
+
+output "log_analytics_workspace_id" {
+  description = "Existing Log Analytics workspace resource ID used by AKS monitoring."
+  value       = data.azurerm_log_analytics_workspace.logs.id
+}
+
 output "aks_id" {
   description = "AKS cluster resource ID."
   value       = var.enable_aks ? module.aks[0].id : null

--- a/infra/envs/dev-platform/provider.tf
+++ b/infra/envs/dev-platform/provider.tf
@@ -1,0 +1,13 @@
+provider "azurerm" {
+  features {}
+  storage_use_azuread = true
+}
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.39"
+    }
+  }
+}

--- a/infra/envs/dev-platform/terraform.tfvars.example
+++ b/infra/envs/dev-platform/terraform.tfvars.example
@@ -24,7 +24,8 @@ log_analytics_resource_group_name   = "rg-chatops-guard-state"
 # When you are ready for the first real AKS plan/apply:
 # 1. change enable_aks to true
 # 2. keep the network defaults or adjust them deliberately
-# 3. add your stable public IP as a /32 if you want demo-time API access restriction
+# 3. add your stable public IP as a /32 because this root now requires
+#    api_server_authorized_ip_ranges when AKS is enabled
 #
 # enable_aks = true
 # api_server_authorized_ip_ranges = [

--- a/infra/envs/dev-platform/terraform.tfvars.example
+++ b/infra/envs/dev-platform/terraform.tfvars.example
@@ -1,5 +1,6 @@
 # Safe default for the first apply of this root:
-# create only rg-chatops-guard-platform-dev and keep AKS off.
+# create rg-chatops-guard-platform-dev plus its minimal VNet/subnet foundation,
+# and keep AKS off.
 enable_aks = false
 
 # Optional overrides for the platform root itself.
@@ -10,14 +11,22 @@ dns_prefix                   = "aks-dev-guard"
 node_count                   = 1
 node_vm_size                 = "Standard_D2_v2"
 
+# Minimal dev network slice managed by this root.
+vnet_name                = "vnet-chatops-guard-dev"
+vnet_address_space       = ["10.30.0.0/16"]
+aks_node_subnet_name     = "snet-aks-nodes"
+aks_node_subnet_prefixes = ["10.30.0.0/24"]
+
+# Existing monitoring dependency looked up from the bootstrap resources.
+log_analytics_workspace_name        = "log-chatops-guard-dev"
+log_analytics_resource_group_name   = "rg-chatops-guard-state"
+
 # When you are ready for the first real AKS plan/apply:
 # 1. change enable_aks to true
-# 2. provide the real network and monitoring dependencies below
+# 2. keep the network defaults or adjust them deliberately
 # 3. add your stable public IP as a /32 if you want demo-time API access restriction
 #
-# enable_aks                  = true
-# vnet_subnet_id              = "/subscriptions/<sub-id>/resourceGroups/rg-chatops-guard-network-dev/providers/Microsoft.Network/virtualNetworks/vnet-chatops-guard-dev/subnets/snet-aks-nodes"
-# log_analytics_workspace_id  = "/subscriptions/<sub-id>/resourceGroups/rg-chatops-guard-state/providers/Microsoft.OperationalInsights/workspaces/log-chatops-guard-dev"
+# enable_aks = true
 # api_server_authorized_ip_ranges = [
 #   "203.0.113.10/32",
 # ]

--- a/infra/envs/dev-platform/terraform.tfvars.example
+++ b/infra/envs/dev-platform/terraform.tfvars.example
@@ -1,0 +1,23 @@
+# Safe default for the first apply of this root:
+# create only rg-chatops-guard-platform-dev and keep AKS off.
+enable_aks = false
+
+# Optional overrides for the platform root itself.
+platform_resource_group_name = "rg-chatops-guard-platform-dev"
+location                     = "westeurope"
+cluster_name                 = "aks-dev-guard"
+dns_prefix                   = "aks-dev-guard"
+node_count                   = 1
+node_vm_size                 = "Standard_D2_v2"
+
+# When you are ready for the first real AKS plan/apply:
+# 1. change enable_aks to true
+# 2. provide the real network and monitoring dependencies below
+# 3. add your stable public IP as a /32 if you want demo-time API access restriction
+#
+# enable_aks                  = true
+# vnet_subnet_id              = "/subscriptions/<sub-id>/resourceGroups/rg-chatops-guard-network-dev/providers/Microsoft.Network/virtualNetworks/vnet-chatops-guard-dev/subnets/snet-aks-nodes"
+# log_analytics_workspace_id  = "/subscriptions/<sub-id>/resourceGroups/rg-chatops-guard-state/providers/Microsoft.OperationalInsights/workspaces/log-chatops-guard-dev"
+# api_server_authorized_ip_ranges = [
+#   "203.0.113.10/32",
+# ]

--- a/infra/envs/dev-platform/var.tf
+++ b/infra/envs/dev-platform/var.tf
@@ -1,0 +1,106 @@
+variable "platform_resource_group_name" {
+  description = "Resource group that will contain the dev platform resources such as AKS."
+  type        = string
+  default     = "rg-chatops-guard-platform-dev"
+
+  validation {
+    condition     = trimspace(var.platform_resource_group_name) != ""
+    error_message = "platform_resource_group_name must not be empty."
+  }
+}
+
+variable "location" {
+  description = "Azure region for the dev platform root."
+  type        = string
+  default     = "westeurope"
+
+  validation {
+    condition     = trimspace(var.location) != ""
+    error_message = "location must not be empty."
+  }
+}
+
+variable "cluster_name" {
+  description = "AKS cluster name for the dev platform root."
+  type        = string
+  default     = "aks-dev-guard"
+
+  validation {
+    condition     = trimspace(var.cluster_name) != ""
+    error_message = "cluster_name must not be empty."
+  }
+}
+
+variable "dns_prefix" {
+  description = "DNS prefix for the dev AKS cluster."
+  type        = string
+  default     = "aks-dev-guard"
+
+  validation {
+    condition     = trimspace(var.dns_prefix) != ""
+    error_message = "dns_prefix must not be empty."
+  }
+}
+
+variable "enable_aks" {
+  description = "Whether this root should create the AKS cluster. Keep false for the first safe apply so only the platform resource group is created."
+  type        = bool
+  default     = false
+}
+
+variable "kubernetes_version" {
+  description = "Optional AKS Kubernetes version. Leave null to let Azure choose a supported default later."
+  type        = string
+  default     = null
+}
+
+variable "node_count" {
+  description = "Initial system node-pool size."
+  type        = number
+  default     = 1
+}
+
+variable "node_vm_size" {
+  description = "VM size for the first dev system pool."
+  type        = string
+  default     = "Standard_D2_v2"
+}
+
+variable "vnet_subnet_id" {
+  description = "Subnet resource ID for the AKS node pool. Required only when enable_aks is true."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.enable_aks || (var.vnet_subnet_id != null && trimspace(var.vnet_subnet_id) != "")
+    error_message = "vnet_subnet_id must be set to a non-empty subnet resource ID when enable_aks is true."
+  }
+}
+
+variable "log_analytics_workspace_id" {
+  description = "Log Analytics workspace resource ID used for AKS monitoring. Required only when enable_aks is true."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.enable_aks || (var.log_analytics_workspace_id != null && trimspace(var.log_analytics_workspace_id) != "")
+    error_message = "log_analytics_workspace_id must be set to a non-empty workspace resource ID when enable_aks is true."
+  }
+}
+
+variable "api_server_authorized_ip_ranges" {
+  description = "Optional public IP ranges allowed to reach the AKS API server."
+  type        = set(string)
+  default     = []
+
+  validation {
+    condition     = alltrue([for cidr in var.api_server_authorized_ip_ranges : trimspace(cidr) != ""])
+    error_message = "api_server_authorized_ip_ranges must not contain empty values."
+  }
+}
+
+variable "tags" {
+  description = "Extra tags to merge into the environment defaults."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/envs/dev-platform/var.tf
+++ b/infra/envs/dev-platform/var.tf
@@ -141,6 +141,11 @@ variable "api_server_authorized_ip_ranges" {
     condition     = alltrue([for cidr in var.api_server_authorized_ip_ranges : trimspace(cidr) != ""])
     error_message = "api_server_authorized_ip_ranges must not contain empty values."
   }
+
+  validation {
+    condition     = !var.enable_aks || length(var.api_server_authorized_ip_ranges) > 0
+    error_message = "api_server_authorized_ip_ranges must be set when enable_aks is true so the first public AKS API is not left unrestricted by accident."
+  }
 }
 
 variable "tags" {

--- a/infra/envs/dev-platform/var.tf
+++ b/infra/envs/dev-platform/var.tf
@@ -1,5 +1,5 @@
 variable "platform_resource_group_name" {
-  description = "Resource group that will contain the dev platform resources such as AKS."
+  description = "Resource group that will contain the dev platform resources such as AKS and its network foundation."
   type        = string
   default     = "rg-chatops-guard-platform-dev"
 
@@ -43,7 +43,7 @@ variable "dns_prefix" {
 }
 
 variable "enable_aks" {
-  description = "Whether this root should create the AKS cluster. Keep false for the first safe apply so only the platform resource group is created."
+  description = "Whether this root should create the AKS cluster. Keep false for the first safe apply so only the platform resource group and network foundation are created."
   type        = bool
   default     = false
 }
@@ -66,25 +66,69 @@ variable "node_vm_size" {
   default     = "Standard_D2_v2"
 }
 
-variable "vnet_subnet_id" {
-  description = "Subnet resource ID for the AKS node pool. Required only when enable_aks is true."
+variable "vnet_name" {
+  description = "Name of the dev platform virtual network."
   type        = string
-  default     = null
+  default     = "vnet-chatops-guard-dev"
 
   validation {
-    condition     = !var.enable_aks || (var.vnet_subnet_id != null && trimspace(var.vnet_subnet_id) != "")
-    error_message = "vnet_subnet_id must be set to a non-empty subnet resource ID when enable_aks is true."
+    condition     = trimspace(var.vnet_name) != ""
+    error_message = "vnet_name must not be empty."
   }
 }
 
-variable "log_analytics_workspace_id" {
-  description = "Log Analytics workspace resource ID used for AKS monitoring. Required only when enable_aks is true."
-  type        = string
-  default     = null
+variable "vnet_address_space" {
+  description = "Address space for the dev platform virtual network."
+  type        = list(string)
+  default     = ["10.30.0.0/16"]
 
   validation {
-    condition     = !var.enable_aks || (var.log_analytics_workspace_id != null && trimspace(var.log_analytics_workspace_id) != "")
-    error_message = "log_analytics_workspace_id must be set to a non-empty workspace resource ID when enable_aks is true."
+    condition     = length(var.vnet_address_space) > 0 && alltrue([for cidr in var.vnet_address_space : trimspace(cidr) != ""])
+    error_message = "vnet_address_space must contain at least one non-empty CIDR block."
+  }
+}
+
+variable "aks_node_subnet_name" {
+  description = "Name of the subnet used by the AKS node pool."
+  type        = string
+  default     = "snet-aks-nodes"
+
+  validation {
+    condition     = trimspace(var.aks_node_subnet_name) != ""
+    error_message = "aks_node_subnet_name must not be empty."
+  }
+}
+
+variable "aks_node_subnet_prefixes" {
+  description = "Address prefixes for the AKS node subnet."
+  type        = list(string)
+  default     = ["10.30.0.0/24"]
+
+  validation {
+    condition     = length(var.aks_node_subnet_prefixes) > 0 && alltrue([for cidr in var.aks_node_subnet_prefixes : trimspace(cidr) != ""])
+    error_message = "aks_node_subnet_prefixes must contain at least one non-empty CIDR block."
+  }
+}
+
+variable "log_analytics_workspace_name" {
+  description = "Name of the existing Log Analytics workspace used for AKS monitoring."
+  type        = string
+  default     = "log-chatops-guard-dev"
+
+  validation {
+    condition     = trimspace(var.log_analytics_workspace_name) != ""
+    error_message = "log_analytics_workspace_name must not be empty."
+  }
+}
+
+variable "log_analytics_resource_group_name" {
+  description = "Resource group that contains the existing Log Analytics workspace used for AKS monitoring."
+  type        = string
+  default     = "rg-chatops-guard-state"
+
+  validation {
+    condition     = trimspace(var.log_analytics_resource_group_name) != ""
+    error_message = "log_analytics_resource_group_name must not be empty."
   }
 }
 

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -1,4 +1,5 @@
-# Example only: keep disabled until a later ticket wires the AKS module into a non-bootstrap root.
+# Example only: keep disabled here because this root stays bootstrap-only.
+# The first real AKS wiring now lives under infra/envs/dev-platform.
 # module "aks" {
 #   source              = "../../modules/aks"
 #   cluster_name        = "aks-dev-guard"

--- a/infra/modules/aks/main.tf
+++ b/infra/modules/aks/main.tf
@@ -13,7 +13,7 @@ resource "azurerm_kubernetes_cluster" "this" {
   kubernetes_version        = var.kubernetes_version
   sku_tier                  = var.sku_tier
   azure_policy_enabled      = true
-  local_account_disabled    = true
+  local_account_disabled    = var.local_account_disabled
   private_cluster_enabled   = var.private_cluster_enabled
   automatic_upgrade_channel = var.automatic_upgrade_channel
 
@@ -36,6 +36,14 @@ resource "azurerm_kubernetes_cluster" "this" {
     vm_size        = var.node_vm_size
     max_pods       = 50
     vnet_subnet_id = var.vnet_subnet_id
+
+    # Make the provider/Azure defaults explicit so the first applied cluster
+    # does not keep showing an in-place node pool diff on the next plan.
+    upgrade_settings {
+      max_surge                     = "10%"
+      drain_timeout_in_minutes      = 0
+      node_soak_duration_in_minutes = 0
+    }
   }
 
   network_profile {

--- a/infra/modules/aks/variables.tf
+++ b/infra/modules/aks/variables.tf
@@ -93,6 +93,12 @@ variable "sku_tier" {
   }
 }
 
+variable "local_account_disabled" {
+  description = "Whether local AKS admin accounts should be disabled. On Kubernetes 1.25+ this requires managed AAD integration, so the demo default stays false until that slice exists."
+  type        = bool
+  default     = false
+}
+
 variable "private_cluster_enabled" {
   description = "Whether the AKS API server should only be exposed on private IP addresses."
   type        = bool

--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -1,0 +1,14 @@
+resource "azurerm_virtual_network" "this" {
+  name                = var.vnet_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  address_space       = var.vnet_address_space
+  tags                = var.tags
+}
+
+resource "azurerm_subnet" "aks_nodes" {
+  name                 = var.aks_node_subnet_name
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = var.aks_node_subnet_prefixes
+}

--- a/infra/modules/network/outputs.tf
+++ b/infra/modules/network/outputs.tf
@@ -1,0 +1,19 @@
+output "vnet_id" {
+  description = "Resource ID of the virtual network."
+  value       = azurerm_virtual_network.this.id
+}
+
+output "vnet_name" {
+  description = "Name of the virtual network."
+  value       = azurerm_virtual_network.this.name
+}
+
+output "aks_node_subnet_id" {
+  description = "Resource ID of the AKS node subnet."
+  value       = azurerm_subnet.aks_nodes.id
+}
+
+output "aks_node_subnet_name" {
+  description = "Name of the AKS node subnet."
+  value       = azurerm_subnet.aks_nodes.name
+}

--- a/infra/modules/network/variables.tf
+++ b/infra/modules/network/variables.tf
@@ -1,0 +1,65 @@
+variable "resource_group_name" {
+  description = "Resource group that will contain the network resources."
+  type        = string
+
+  validation {
+    condition     = trimspace(var.resource_group_name) != ""
+    error_message = "resource_group_name must not be empty."
+  }
+}
+
+variable "location" {
+  description = "Azure region for the network resources."
+  type        = string
+
+  validation {
+    condition     = trimspace(var.location) != ""
+    error_message = "location must not be empty."
+  }
+}
+
+variable "vnet_name" {
+  description = "Name of the virtual network."
+  type        = string
+
+  validation {
+    condition     = trimspace(var.vnet_name) != ""
+    error_message = "vnet_name must not be empty."
+  }
+}
+
+variable "vnet_address_space" {
+  description = "Address space for the virtual network."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.vnet_address_space) > 0 && alltrue([for cidr in var.vnet_address_space : trimspace(cidr) != ""])
+    error_message = "vnet_address_space must contain at least one non-empty CIDR block."
+  }
+}
+
+variable "aks_node_subnet_name" {
+  description = "Name of the subnet used by the AKS node pool."
+  type        = string
+
+  validation {
+    condition     = trimspace(var.aks_node_subnet_name) != ""
+    error_message = "aks_node_subnet_name must not be empty."
+  }
+}
+
+variable "aks_node_subnet_prefixes" {
+  description = "Address prefixes for the AKS node subnet."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.aks_node_subnet_prefixes) > 0 && alltrue([for cidr in var.aks_node_subnet_prefixes : trimspace(cidr) != ""])
+    error_message = "aks_node_subnet_prefixes must contain at least one non-empty CIDR block."
+  }
+}
+
+variable "tags" {
+  description = "Tags to apply to the network resources."
+  type        = map(string)
+  default     = {}
+}

--- a/infra/modules/network/versions.tf
+++ b/infra/modules/network/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.39"
+    }
+  }
+}

--- a/plan.md
+++ b/plan.md
@@ -10,7 +10,8 @@
 - The `dev` remote state is aligned with Azure again after importing the pre-existing bootstrap resources and correcting the storage diagnostics scope.
 - `infra/envs/prod` remains a dormant placeholder.
 - `infra/modules/aks` exists as the first reusable platform module.
-- `infra/envs/dev-platform` is the first thin non-bootstrap platform root that composes it. It now has its own backend/state and has been safely applied once to create only `rg-chatops-guard-platform-dev`, while AKS remains disabled by default.
+- `infra/modules/network` now exists as a sibling module for the minimal VNet/subnet foundation.
+- `infra/envs/dev-platform` is the first thin non-bootstrap platform root that composes both modules. It now has its own backend/state, has safely applied `rg-chatops-guard-platform-dev` plus the first VNet/subnet foundation, and can produce a real `enable_aks = true` AKS plan while AKS remains disabled by default.
 
 ## CI/CD Flow
 1. `tf-plan-apply` workflow (GitHub Actions) runs in matrix mode over `TF_TARGET_ENVS` (defaults to `["dev"]`).
@@ -40,22 +41,22 @@
 ## Next Steps
 1. Close stale issue hygiene for delivered workflow/bootstrap work if GitHub has not already caught up, especially issue `#43`.
 2. Keep AKS disabled in `infra/envs/dev`; the bootstrap root should not silently grow into the long-term platform root.
-3. Keep `vnet_subnet_id` and `log_analytics_workspace_id` as explicit injected inputs for now, and use `terraform.tfvars.example` as the contract for the first real cluster rollout.
-4. Fill in the real dependency values before the first `enable_aks = true` plan/apply.
-5. Only after that, flip `enable_aks` on deliberately and plan the first real cluster rollout.
+3. Keep AKS disabled by default until PR #51 is reviewed and the demo-risk tradeoff is accepted.
+4. Decide whether the first real AKS apply in dev should happen in this PR or as the immediate follow-up after merge.
+5. Before the first apply, set `api_server_authorized_ip_ranges` to your stable public IP if you want the demo cluster API restricted from day one.
 6. Then revisit additional dev hardening upgrades such as SAS policy, CMK, private endpoints, or GRS.
 
 ## ROI Priority Order (2026-04-16)
 
 ### Recommendation
 - Treat bootstrap/state recovery and the recent workflow cleanup as done unless drift or apply proves otherwise.
-- Treat the next AKS slice as staged environment-composition work on `infra/envs/dev-platform`: first the guarded root and platform RG, then dependency wiring, and only then a real cluster apply.
+- Treat the next AKS slice as staged environment-composition work on `infra/envs/dev-platform`: guarded root, platform RG, minimal network foundation, first real AKS plan, and only then a deliberate cluster apply.
 - Use issue `#12` as the architecture anchor until a dedicated follow-up AKS env-root issue exists.
 - Use umbrella issues such as `#2` and `#13` for tracking only; do not let them outrank the scoped implementation work.
 
 ### Highest ROI / lowest direct cloud cost
-1. Turn reusable Terraform into the first thin platform root and finish its input wiring before provisioning a real cluster:
-   - `#12` plus the AKS env-root wiring follow-up
+1. Finish the staged dev-platform rollout path and decide whether to run the first real AKS apply:
+   - `#12` plus `#50`
 2. Improve supply-chain and project automation with mostly engineering time, not cloud spend:
    - `#28`, `#30`, `#38`, `#39`
 3. Close stale issue hygiene for recently delivered work:
@@ -76,8 +77,8 @@
 ## Suggested Sequence
 1. Reconcile issue hygiene for delivered infra and workflow work (`#1`, `#14`, `#15`, `#43`).
 2. Keep AKS work on `infra/envs/dev-platform` instead of adding more module-only hardening or mixing platform resources into `infra/envs/dev`.
-3. Keep the first real dev platform root on explicit injected network and monitoring inputs for now, documented in `terraform.tfvars.example`.
-4. Fill in the real dependency values.
-5. Only after that, flip `enable_aks` on and plan the first real cluster rollout.
+3. Use the new `infra/modules/network` foundation and the existing Log Analytics workspace lookup as the demo-ready dependency path.
+4. Decide whether the first real AKS apply should land in PR #51 or the immediate next PR.
+5. Set demo-safe API access restrictions before the first apply if needed.
 6. Keep docs aligned with the actual branch and merge state so planning does not outrun code again.
 7. Then return to the smallest application skeleton work.

--- a/plan.md
+++ b/plan.md
@@ -9,7 +9,8 @@
   - blob-service diagnostics for the state account
 - The `dev` remote state is aligned with Azure again after importing the pre-existing bootstrap resources and correcting the storage diagnostics scope.
 - `infra/envs/prod` remains a dormant placeholder.
-- `infra/modules/aks` exists as the first reusable platform module, but it is still not wired into a non-bootstrap environment root. That makes issue `#15` the real infrastructure next step, not more bootstrap repair.
+- `infra/modules/aks` exists as the first reusable platform module.
+- `infra/envs/dev-platform` is the first thin non-bootstrap platform root that composes it. It now has its own backend/state and has been safely applied once to create only `rg-chatops-guard-platform-dev`, while AKS remains disabled by default.
 
 ## CI/CD Flow
 1. `tf-plan-apply` workflow (GitHub Actions) runs in matrix mode over `TF_TARGET_ENVS` (defaults to `["dev"]`).
@@ -38,24 +39,27 @@
 
 ## Next Steps
 1. Close stale issue hygiene for delivered workflow/bootstrap work if GitHub has not already caught up, especially issue `#43`.
-2. Continue issue `#15` by designing the first non-bootstrap environment wiring for AKS. Do not apply AKS in `dev` yet; decide the env-root shape first.
-3. Keep AKS disabled in `infra/envs/dev`; the bootstrap root should not silently grow into the long-term platform root.
-4. Only after the AKS env-root decision is settled, revisit additional dev hardening upgrades such as SAS policy, CMK, private endpoints, or GRS.
+2. Keep AKS disabled in `infra/envs/dev`; the bootstrap root should not silently grow into the long-term platform root.
+3. Keep `vnet_subnet_id` and `log_analytics_workspace_id` as explicit injected inputs for now, and use `terraform.tfvars.example` as the contract for the first real cluster rollout.
+4. Fill in the real dependency values before the first `enable_aks = true` plan/apply.
+5. Only after that, flip `enable_aks` on deliberately and plan the first real cluster rollout.
+6. Then revisit additional dev hardening upgrades such as SAS policy, CMK, private endpoints, or GRS.
 
 ## ROI Priority Order (2026-04-16)
 
 ### Recommendation
 - Treat bootstrap/state recovery and the recent workflow cleanup as done unless drift or apply proves otherwise.
-- Keep AKS work on issue `#15` focused on environment wiring and explicit design decisions, not on provisioning a real cluster yet.
+- Treat the next AKS slice as staged environment-composition work on `infra/envs/dev-platform`: first the guarded root and platform RG, then dependency wiring, and only then a real cluster apply.
+- Use issue `#12` as the architecture anchor until a dedicated follow-up AKS env-root issue exists.
 - Use umbrella issues such as `#2` and `#13` for tracking only; do not let them outrank the scoped implementation work.
 
 ### Highest ROI / lowest direct cloud cost
-1. Continue reusable Terraform without provisioning more Azure resources:
-   - `#15`
+1. Turn reusable Terraform into the first thin platform root and finish its input wiring before provisioning a real cluster:
+   - `#12` plus the AKS env-root wiring follow-up
 2. Improve supply-chain and project automation with mostly engineering time, not cloud spend:
    - `#28`, `#30`, `#38`, `#39`
 3. Close stale issue hygiene for recently delivered work:
-   - `#1`, `#43`
+   - `#1`, `#15`, `#43`
 
 ### Medium ROI / moderate setup cost
 4. Complete delivery plumbing once images and charts exist:
@@ -70,7 +74,10 @@
    - `#23`, `#25`, `#26`, `#37`
 
 ## Suggested Sequence
-1. Reconcile issue hygiene for delivered infra and workflow work (`#1`, `#14`, `#43`).
-2. Resume AKS design from the environment-wiring side instead of adding more skeleton-only hardening.
-3. Keep docs aligned with the actual branch and merge state so planning does not outrun code again.
-4. Then return to the smallest application skeleton work.
+1. Reconcile issue hygiene for delivered infra and workflow work (`#1`, `#14`, `#15`, `#43`).
+2. Keep AKS work on `infra/envs/dev-platform` instead of adding more module-only hardening or mixing platform resources into `infra/envs/dev`.
+3. Keep the first real dev platform root on explicit injected network and monitoring inputs for now, documented in `terraform.tfvars.example`.
+4. Fill in the real dependency values.
+5. Only after that, flip `enable_aks` on and plan the first real cluster rollout.
+6. Keep docs aligned with the actual branch and merge state so planning does not outrun code again.
+7. Then return to the smallest application skeleton work.

--- a/plan.md
+++ b/plan.md
@@ -12,6 +12,9 @@
 - `infra/modules/aks` exists as the first reusable platform module.
 - `infra/modules/network` now exists as a sibling module for the minimal VNet/subnet foundation.
 - `infra/envs/dev-platform` is the first thin non-bootstrap platform root that composes both modules. It now has its own backend/state, has safely applied `rg-chatops-guard-platform-dev` plus the first VNet/subnet foundation, and can produce a real `enable_aks = true` AKS plan while AKS remains disabled by default.
+- `infra/envs/dev-platform` now also requires `api_server_authorized_ip_ranges` when `enable_aks = true`, so the first public dev AKS apply does not expose the API server broadly by accident.
+- The first AKS rollout path is local-first: use an untracked `infra/envs/dev-platform/terraform.tfvars` for `enable_aks = true` plus a local `/32` admin IP. `dev-platform` is still intentionally outside GitHub `tf-plan-apply` for now.
+- The first demo AKS rollout keeps local accounts enabled for now; disabling them is deferred into issue `#52` because AKS rejects `disableLocalAccounts=true` on Kubernetes 1.25+ clusters without managed AAD / Entra ID integration.
 
 ## CI/CD Flow
 1. `tf-plan-apply` workflow (GitHub Actions) runs in matrix mode over `TF_TARGET_ENVS` (defaults to `["dev"]`).
@@ -42,8 +45,8 @@
 1. Close stale issue hygiene for delivered workflow/bootstrap work if GitHub has not already caught up, especially issue `#43`.
 2. Keep AKS disabled in `infra/envs/dev`; the bootstrap root should not silently grow into the long-term platform root.
 3. Keep AKS disabled by default until PR #51 is reviewed and the demo-risk tradeoff is accepted.
-4. Decide whether the first real AKS apply in dev should happen in this PR or as the immediate follow-up after merge.
-5. Before the first apply, set `api_server_authorized_ip_ranges` to your stable public IP if you want the demo cluster API restricted from day one.
+4. Open a focused follow-up CI PR to add `dev-platform` to GitHub validation first, and only then decide whether to add it to `tf-plan-apply`.
+5. Track managed Entra ID integration and `disableLocalAccounts=true` under issue `#52`.
 6. Then revisit additional dev hardening upgrades such as SAS policy, CMK, private endpoints, or GRS.
 
 ## ROI Priority Order (2026-04-16)
@@ -55,7 +58,7 @@
 - Use umbrella issues such as `#2` and `#13` for tracking only; do not let them outrank the scoped implementation work.
 
 ### Highest ROI / lowest direct cloud cost
-1. Finish the staged dev-platform rollout path and decide whether to run the first real AKS apply:
+1. Finish the staged dev-platform rollout path and transition it into GitHub validation:
    - `#12` plus `#50`
 2. Improve supply-chain and project automation with mostly engineering time, not cloud spend:
    - `#28`, `#30`, `#38`, `#39`
@@ -78,7 +81,8 @@
 1. Reconcile issue hygiene for delivered infra and workflow work (`#1`, `#14`, `#15`, `#43`).
 2. Keep AKS work on `infra/envs/dev-platform` instead of adding more module-only hardening or mixing platform resources into `infra/envs/dev`.
 3. Use the new `infra/modules/network` foundation and the existing Log Analytics workspace lookup as the demo-ready dependency path.
-4. Decide whether the first real AKS apply should land in PR #51 or the immediate next PR.
-5. Set demo-safe API access restrictions before the first apply if needed.
-6. Keep docs aligned with the actual branch and merge state so planning does not outrun code again.
-7. Then return to the smallest application skeleton work.
+4. Keep PR #51 focused on the root/network/monitoring contract and the now-proven local AKS rollout.
+5. Add `dev-platform` to GitHub validation in a follow-up CI PR.
+6. Handle managed Entra ID integration and local-account hardening in issue `#52`.
+7. Keep docs aligned with the actual branch and merge state so planning does not outrun code again.
+8. Then return to the smallest application skeleton work.


### PR DESCRIPTION
Closes #50

## Summary
- add the first non-bootstrap `infra/envs/dev-platform` Terraform root
- give that root its own backend key and provider config
- compose `infra/modules/aks` from that root instead of the live bootstrap root
- keep AKS behind `enable_aks = false` by default so the first safe apply creates only the platform resource group
- add conditional validation for `vnet_subnet_id` and `log_analytics_workspace_id` when `enable_aks = true`
- add `terraform.tfvars.example` to document the safe-first-apply path and the future AKS-enabled path
- update docs and plan notes to explain bootstrap vs non-bootstrap roots and the staged rollout path

## What was applied already
- initialized the new `infra/envs/dev-platform` backend
- applied the root once with `enable_aks = false`
- created only `rg-chatops-guard-platform-dev`
- reran plan and confirmed `No changes`

## Validation
- `terraform -chdir=infra/envs/dev-platform fmt -check`
- `terraform -chdir=infra/envs/dev-platform init -backend=false -input=false`
- `terraform -chdir=infra/envs/dev-platform validate`
- `terraform -chdir=infra/envs/dev-platform init -input=false`
- `terraform -chdir=infra/envs/dev-platform plan -out=tfplan`
- `terraform -chdir=infra/envs/dev-platform apply tfplan`
- `terraform -chdir=infra/envs/dev-platform plan`
- `terraform -chdir=infra/envs/dev-platform plan -var=enable_aks=true`
  - expected failure without `vnet_subnet_id` and `log_analytics_workspace_id`

## Deferred follow-up
- decide where the real `vnet_subnet_id` should come from
- decide where the real `log_analytics_workspace_id` should come from
- only then run the first `enable_aks = true` AKS plan/apply