### PR TITLE
ci(terraform): add dev-platform to GitHub workflows

### DIFF
--- a/.github/workflows/tf-destroy.yaml
+++ b/.github/workflows/tf-destroy.yaml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - dev
+          - dev-platform
           - prod
         default: dev
       confirm_destroy:

--- a/.github/workflows/tf-plan-apply.yaml
+++ b/.github/workflows/tf-plan-apply.yaml
@@ -27,7 +27,7 @@ env:
   ARM_CLIENT_ID: "${{ secrets.AZURE_CLIENT_ID }}"
   ARM_SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
   ARM_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
-  TF_TARGET_ENVS: ${{ vars.TF_TARGET_ENVS || '["dev"]' }}
+  TF_TARGET_ENVS: ${{ vars.TF_TARGET_ENVS || '["dev","dev-platform"]' }}
 
 jobs:
   terraform-plan:
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: ${{ fromJson(vars.TF_TARGET_ENVS || '["dev"]') }}
+        environment: ${{ fromJson(vars.TF_TARGET_ENVS || '["dev","dev-platform"]') }}
     env:
       ARM_SKIP_PROVIDER_REGISTRATION: true
       TF_ENV_DIR: infra/envs/${{ matrix.environment }}
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: ${{ fromJson(vars.TF_TARGET_ENVS || '["dev"]') }}
+        environment: ${{ fromJson(vars.TF_TARGET_ENVS || '["dev","dev-platform"]') }}
     timeout-minutes: 30
     env:
       TF_ENV_DIR: infra/envs/${{ matrix.environment }}

--- a/.github/workflows/tf-unit-tests.yaml
+++ b/.github/workflows/tf-unit-tests.yaml
@@ -39,10 +39,11 @@ jobs:
       with:
         terraform_wrapper: false
 
-    # Initialize and validate both the live dev root and the AKS module skeleton.
+    # Initialize and validate the live bootstrap root, the dev platform root,
+    # and the reusable AKS module when it exists.
     - name: Terraform Init
       run: |
-        dirs="infra/envs/dev"
+        dirs="infra/envs/dev infra/envs/dev-platform"
         if [ -d infra/modules/aks ]; then
           dirs="$dirs infra/modules/aks"
         fi
@@ -52,7 +53,7 @@ jobs:
 
     - name: Terraform Validate
       run: |
-        dirs="infra/envs/dev"
+        dirs="infra/envs/dev infra/envs/dev-platform"
         if [ -d infra/modules/aks ]; then
           dirs="$dirs infra/modules/aks"
         fi
@@ -62,7 +63,7 @@ jobs:
 
     - name: Terraform Format
       run: |
-        dirs="infra/envs/dev"
+        dirs="infra/envs/dev infra/envs/dev-platform"
         if [ -d infra/modules/aks ]; then
           dirs="$dirs infra/modules/aks"
         fi

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ Configuration details and examples will be documented as features are implemente
   - the Log Analytics workspace used for storage diagnostics
   - the blob-service diagnostic setting that sends storage logs/metrics to Log Analytics
 - `infra/modules/aks` now exists as the first reusable platform module, and `infra/envs/dev-platform` is the first thin non-bootstrap root that composes it. That root now has its own backend/state, has safely applied `rg-chatops-guard-platform-dev` plus a minimal VNet/subnet foundation, and can produce a real `enable_aks = true` plan while AKS still stays explicitly gated by default. When AKS is enabled there, `api_server_authorized_ip_ranges` must also be set so the first demo cluster does not leave its public API open unintentionally.
-- The first AKS rollout path is intentionally local-first: use an untracked `infra/envs/dev-platform/terraform.tfvars` for `enable_aks = true` and your local `/32` admin IP. `dev-platform` is not in GitHub `tf-plan-apply` yet, by design.
+- The first AKS rollout path was intentionally local-first to prove the cluster create with an untracked `infra/envs/dev-platform/terraform.tfvars` and a local `/32` admin IP.
+- GitHub Terraform workflows now target both `dev` and `dev-platform` by default, so future AKS Terraform changes can be planned/applied from Actions as well.
 - The first demo AKS cluster keeps local accounts enabled for now because disabling them on Kubernetes 1.25+ requires managed AAD integration. That hardening step is now tracked in issue `#52` until the Entra ID/RBAC slice is introduced.
 - Production definitions exist but remain dormant until explicitly enabled via GitHub Actions `TF_TARGET_ENVS`.
 - GitHub Actions workflow `.github/workflows/tf-plan-apply.yaml` uses a matrix to run `plan/apply` per environment while scoping Terraform commands to `infra/envs/<env>` so prod is untouched unless opted in.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -39,7 +39,7 @@ This file is a grouped planning view of the current backlog after the recent boo
   - [x] Set `api_server_authorized_ip_ranges` locally before the first apply; `enable_aks = true` now requires it
   - [x] Keep `local_account_disabled = false` for the first demo cluster until managed AAD integration exists
   - [x] Prove the first local `enable_aks = true` apply from `infra/envs/dev-platform`
-  - [ ] Add `dev-platform` to GitHub validation in a follow-up CI PR after the local AKS rollout is proven
+  - [x] Add `dev-platform` GitHub validation/plan-apply follow-up issue `#53`
   - [ ] #52 INF-07 · AKS managed Entra ID integration and disable local accounts
   - [ ] Keep AKS design decisions explicit: egress, admin access path, private-cluster timing
   - [ ] #16 INF-03 · Event Grid + Topic
@@ -64,6 +64,7 @@ This file is a grouped planning view of the current backlog after the recent boo
 - Tasks:
   - [ ] #2 Add Ci&CD to the repo
   - [ ] Close issue #43 now that the repaired `tf-drift` workflow is stable again
+  - [ ] #53 CI-04 · Add dev-platform to Terraform GitHub validation and plan/apply
   - [ ] #28 SEC-01 · Trivy image + IaC scan gate
   - [ ] #30 SEC-03 · SBOM generation & upload
   - [ ] #31 CI-01 · Build & push images to ACR

--- a/docs/terraform-architecture.md
+++ b/docs/terraform-architecture.md
@@ -87,7 +87,7 @@ Why the name is explicit right now:
 The network side is now handled by `infra/modules/network`, and the monitoring side is resolved through an explicit Log Analytics workspace lookup from the existing bootstrap resources.
 
 That local rollout proof is now done. The next real decisions are:
-- add `infra/envs/dev-platform` to GitHub validation as a focused follow-up CI slice
+- land the focused follow-up CI slice in issue `#53` so `infra/envs/dev-platform` participates in GitHub Terraform validation and plan/apply
 - handle managed Entra ID integration in issue `#52`
 
 That keeps the already-applied `dev` state stable while moving AKS work from module-only scaffolding toward real environment composition.

--- a/plan.md
+++ b/plan.md
@@ -11,13 +11,13 @@
 - `infra/envs/prod` remains a dormant placeholder.
 - `infra/modules/aks` exists as the first reusable platform module.
 - `infra/modules/network` now exists as a sibling module for the minimal VNet/subnet foundation.
-- `infra/envs/dev-platform` is the first thin non-bootstrap platform root that composes both modules. It now has its own backend/state, has safely applied `rg-chatops-guard-platform-dev` plus the first VNet/subnet foundation, and can produce a real `enable_aks = true` AKS plan while AKS remains disabled by default.
+- `infra/envs/dev-platform` is the first thin non-bootstrap platform root that composes both modules. It now has its own backend/state, has safely applied `rg-chatops-guard-platform-dev` plus the first VNet/subnet foundation, and has already completed the first local `enable_aks = true` AKS apply with a clean post-apply plan.
 - `infra/envs/dev-platform` now also requires `api_server_authorized_ip_ranges` when `enable_aks = true`, so the first public dev AKS apply does not expose the API server broadly by accident.
 - The first AKS rollout path is local-first: use an untracked `infra/envs/dev-platform/terraform.tfvars` for `enable_aks = true` plus a local `/32` admin IP. `dev-platform` is still intentionally outside GitHub `tf-plan-apply` for now.
 - The first demo AKS rollout keeps local accounts enabled for now; disabling them is deferred into issue `#52` because AKS rejects `disableLocalAccounts=true` on Kubernetes 1.25+ clusters without managed AAD / Entra ID integration.
 
 ## CI/CD Flow
-1. `tf-plan-apply` workflow (GitHub Actions) runs in matrix mode over `TF_TARGET_ENVS` (defaults to `["dev"]`).
+1. `tf-plan-apply` workflow (GitHub Actions) runs in matrix mode over `TF_TARGET_ENVS` (defaults to `["dev","dev-platform"]`).
 2. Each matrix job:
    - Logs into Azure with OIDC.
    - Runs Terraform init/fmt/validate/plan under `infra/envs/<env>` using `-chdir`.
@@ -25,7 +25,7 @@
    - Uploads the per-environment plan artifact and computed exit code.
 3. Apply jobs download the matching artifact, inspect the exit code, and only run `terraform apply` when changes exist and the branch is `main`.
 4. `tf-drift` is now scoped to `infra/envs/dev`, uses Azure OIDC login, and should keep stale drift issues closed when no changes exist.
-5. `tf-unit-tests.yaml` now validates the live `dev` root and tolerates optional module paths, while `tf-destroy.yaml` provides a guarded manual destroy path for cost-control or teardown scenarios.
+5. `tf-unit-tests.yaml` now validates the live `dev` root, `dev-platform`, and tolerates optional module paths, while `tf-destroy.yaml` provides a guarded manual destroy path for cost-control or teardown scenarios, including `dev-platform`.
 
 ## Security Hardening Status (Dev)
 | Control | Status | Notes |
@@ -45,7 +45,7 @@
 1. Close stale issue hygiene for delivered workflow/bootstrap work if GitHub has not already caught up, especially issue `#43`.
 2. Keep AKS disabled in `infra/envs/dev`; the bootstrap root should not silently grow into the long-term platform root.
 3. Keep AKS disabled by default until PR #51 is reviewed and the demo-risk tradeoff is accepted.
-4. Open a focused follow-up CI PR to add `dev-platform` to GitHub validation first, and only then decide whether to add it to `tf-plan-apply`.
+4. Review the first GitHub runs that now include `dev-platform` and confirm the rollout behaves cleanly in Actions.
 5. Track managed Entra ID integration and `disableLocalAccounts=true` under issue `#52`.
 6. Then revisit additional dev hardening upgrades such as SAS policy, CMK, private endpoints, or GRS.
 
@@ -58,7 +58,7 @@
 - Use umbrella issues such as `#2` and `#13` for tracking only; do not let them outrank the scoped implementation work.
 
 ### Highest ROI / lowest direct cloud cost
-1. Finish the staged dev-platform rollout path and transition it into GitHub validation:
+1. Finish the staged dev-platform rollout path and keep the new GitHub Terraform coverage stable:
    - `#12` plus `#50`
 2. Improve supply-chain and project automation with mostly engineering time, not cloud spend:
    - `#28`, `#30`, `#38`, `#39`
@@ -82,7 +82,7 @@
 2. Keep AKS work on `infra/envs/dev-platform` instead of adding more module-only hardening or mixing platform resources into `infra/envs/dev`.
 3. Use the new `infra/modules/network` foundation and the existing Log Analytics workspace lookup as the demo-ready dependency path.
 4. Keep PR #51 focused on the root/network/monitoring contract and the now-proven local AKS rollout.
-5. Add `dev-platform` to GitHub validation in a follow-up CI PR.
+5. Land the follow-up CI PR for issue `#53` so `dev-platform` participates in GitHub Terraform validation and plan/apply.
 6. Handle managed Entra ID integration and local-account hardening in issue `#52`.
 7. Keep docs aligned with the actual branch and merge state so planning does not outrun code again.
 8. Then return to the smallest application skeleton work.


### PR DESCRIPTION
Closes #53

## Summary
- add `infra/envs/dev-platform` to Terraform validation in GitHub Actions
- include `dev-platform` in the default Terraform `plan/apply` target set
- add `dev-platform` to the guarded destroy workflow options
- update docs so the GitHub workflow behavior matches the now-proven local AKS rollout

## Why this is stacked
This PR is intentionally based on `feature/issue-50-dev-platform-root` while PR #51 is still open. Once PR #51 merges, this PR can be retargeted to `main`.

## Validation
- `git diff --check`
- workflow YAML parser could not be run on the host because the required parser tooling was unavailable; final validation will come from GitHub Actions on this PR