### PR TITLE
devx: add local validation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,21 @@ We welcome contributions to ChatOps Guard! Here's how you can help:
 
 ### Development Setup
 
-Development setup instructions will be added as the project structure is established.
+For Terraform and workflow changes, use the local validation helper before pushing:
+
+```bash
+scripts/local_validate.sh
+```
+
+From the Flatpak/toolbox setup used for this project:
+
+```bash
+flatpak-spawn --host toolbox run -c dev bash -lc 'cd /var/home/maxmanus/Dokumente/Coding/chatops-guard && scripts/local_validate.sh'
+```
+
+The helper checks the same low-cost path we care about locally: workflow YAML parsing, `actionlint`, Terraform format/init/validate, and Checkov scans for the active Terraform roots. The expected toolbox tools are Terraform, Checkov, PyYAML, Ruby, and actionlint.
+
+The GitHub Wiki should stay a navigation layer, not a second source of truth. A starter Wiki page is tracked at [docs/wiki/Home.md](docs/wiki/Home.md) so changes remain reviewable before being copied or synced to the GitHub Wiki.
 
 ## Security
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -75,6 +75,7 @@ This file is a grouped planning view of the current backlog after the recent boo
   - [x] #55 Extend tf-drift to cover dev-platform with environment-aware drift issues
   - [x] #60 CI-05 · Static automated PR quality review gate
   - [x] #62 SEC-04 · Harden Terraform workflow guardrails and Azure OIDC least privilege
+  - [x] #70 DEVX-01 · Add local validation runner and Wiki starter docs
   - [ ] After split Azure identities are proven, remove the legacy `AZURE_CLIENT_ID` fallback from Terraform workflows
   - [ ] #28 SEC-01 · Trivy image + IaC scan gate
   - [ ] #30 SEC-03 · SBOM generation & upload

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14,7 +14,7 @@ This file is a grouped planning view of the current backlog after the recent boo
 - Tasks:
   - [x] #14 INF-01 · Remote state RG & Storage
   - [x] #46 stale drift issue closed after the recovered `dev` root returned to clean drift behavior
-  - [ ] Close issue #43 now that `tf-drift` is working again
+  - [x] Close issue #43 now that `tf-drift` is working again
   - [ ] Reconcile or close #5 Draft terraform folder and do initial commit if the current repo already satisfies it
   - [ ] Keep #13 Seed backlog aligned with the infrastructure child issues that remain open
 
@@ -70,7 +70,7 @@ This file is a grouped planning view of the current backlog after the recent boo
 - Dependencies: issue hygiene cleanup after the recent merges, image naming/versioning strategy
 - Tasks:
   - [ ] #2 Add Ci&CD to the repo
-  - [ ] Close issue #43 now that the repaired `tf-drift` workflow is stable again
+  - [x] Close issue #43 now that the repaired `tf-drift` workflow is stable again
   - [x] #53 CI-04 · Add dev-platform to Terraform GitHub validation and plan/apply
   - [x] #55 Extend tf-drift to cover dev-platform with environment-aware drift issues
   - [x] #60 CI-05 · Static automated PR quality review gate

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,43 @@
+# ChatOps Guard Wiki
+
+This Wiki page is intentionally small. Keep the repository docs as the source
+of truth because they are reviewed through pull requests and CI.
+
+## Start Here
+
+- Project overview: `README.md`
+- Infra and workflow plan: `plan.md`
+- Current backlog: `docs/TODO.md`
+- Terraform architecture: `docs/terraform-architecture.md`
+- Azure OIDC least privilege notes: `docs/azure-oidc-least-privilege.md`
+
+## Current Project Reality
+
+ChatOps Guard is currently infrastructure-first. The active Terraform work is
+focused on Azure bootstrap resources, GitHub Actions automation, and the staged
+`dev-platform` AKS path. Product application code is still mostly roadmap
+material.
+
+## Local Validation
+
+Run the repo-backed local validation helper before pushing workflow or
+Terraform changes:
+
+```bash
+scripts/local_validate.sh
+```
+
+From the Flatpak/toolbox host setup used in this project:
+
+```bash
+flatpak-spawn --host toolbox run -c dev bash -lc 'cd /var/home/maxmanus/Dokumente/Coding/chatops-guard && scripts/local_validate.sh'
+```
+
+This mirrors the low-cost CI checks where practical: YAML parsing, actionlint,
+Terraform format/init/validate, and Checkov scans for the active Terraform
+roots.
+
+## Wiki Policy
+
+Do not let the Wiki become a second source of truth. Use it as a lightweight
+navigation page that points back to reviewed repo documentation.

--- a/plan.md
+++ b/plan.md
@@ -58,7 +58,7 @@
 4. Watch the first scheduled/manual drift run from merged PR `#59` to confirm separate drift issues per environment.
 5. Configure split Azure identities in GitHub secrets when ready: `AZURE_PLAN_CLIENT_ID` for plan/drift and `AZURE_APPLY_CLIENT_ID` for apply/destroy.
 6. After split identities are proven, remove the legacy `AZURE_CLIENT_ID` fallback from Terraform workflows.
-7. Close stale issue hygiene for delivered workflow/bootstrap work if GitHub has not already caught up, especially issue `#43`.
+7. Continue stale issue hygiene for delivered workflow/bootstrap work if GitHub has not already caught up.
 8. Then revisit additional dev hardening upgrades such as SAS policy, CMK, private endpoints, or GRS.
 
 ## ROI Priority Order (2026-04-25)
@@ -75,7 +75,7 @@
 2. Improve supply-chain and project automation with mostly engineering time, not cloud spend:
    - `#28`, `#30`, `#38`, `#39`, `#60`, `#62`, `#70`
 3. Close stale issue hygiene for recently delivered work:
-   - `#1`, `#15`, `#43`
+   - `#1`, `#15`
 
 ### Medium ROI / moderate setup cost
 4. Complete delivery plumbing once images and charts exist:
@@ -90,7 +90,7 @@
    - `#23`, `#25`, `#26`, `#37`
 
 ## Suggested Sequence
-1. Reconcile issue hygiene for delivered infra and workflow work (`#1`, `#14`, `#15`, `#43`).
+1. Reconcile issue hygiene for delivered infra and workflow work (`#1`, `#14`, `#15`).
 2. Keep AKS work on `infra/envs/dev-platform` instead of adding more module-only hardening or mixing platform resources into `infra/envs/dev`.
 3. Use the new `infra/modules/network` foundation and the existing Log Analytics workspace lookup as the demo-ready dependency path.
 4. Keep AKS cost controlled: `enable_aks = false` remains the repo default, and intentional enables need an explicit teardown path.

--- a/plan.md
+++ b/plan.md
@@ -34,6 +34,7 @@
 6. Dependabot is enabled for GitHub Actions and Terraform provider updates so dependency bumps arrive as reviewable PRs instead of silent drift.
 7. `tf-unit-tests.yaml` now validates the live `dev` root, `dev-platform`, and local modules, and Checkov SARIF now covers both active roots.
 8. `tf-destroy.yaml` provides a guarded manual destroy path for cost-control or teardown scenarios. Destroy defaults to `dev-platform`; destroying `dev` requires an extra bootstrap/state confirmation phrase.
+9. `scripts/local_validate.sh` mirrors the low-cost local checks before push: YAML parsing, `actionlint`, Terraform format/init/validate, and Checkov for the active Terraform roots.
 
 ## Security Hardening Status (Dev)
 | Control | Status | Notes |
@@ -55,7 +56,7 @@
 2. Keep AKS disabled in `infra/envs/dev`; the bootstrap root should not silently grow into the long-term platform root.
 3. Keep AKS disabled by default for cost control unless there is an active demo/learning session and a clear teardown plan.
 4. Watch the first scheduled/manual drift run from merged PR `#59` to confirm separate drift issues per environment.
-5. Merge the issue `#62` workflow/security PR, then configure split Azure identities in GitHub secrets when ready.
+5. Configure split Azure identities in GitHub secrets when ready: `AZURE_PLAN_CLIENT_ID` for plan/drift and `AZURE_APPLY_CLIENT_ID` for apply/destroy.
 6. After split identities are proven, remove the legacy `AZURE_CLIENT_ID` fallback from Terraform workflows.
 7. Close stale issue hygiene for delivered workflow/bootstrap work if GitHub has not already caught up, especially issue `#43`.
 8. Then revisit additional dev hardening upgrades such as SAS policy, CMK, private endpoints, or GRS.
@@ -72,7 +73,7 @@
 1. Finish the staged dev-platform rollout path and keep the new GitHub Terraform coverage stable:
    - `#12`, `#50`, `#53`, `#55`
 2. Improve supply-chain and project automation with mostly engineering time, not cloud spend:
-   - `#28`, `#30`, `#38`, `#39`, `#60`, `#62`
+   - `#28`, `#30`, `#38`, `#39`, `#60`, `#62`, `#70`
 3. Close stale issue hygiene for recently delivered work:
    - `#1`, `#15`, `#43`
 

--- a/scripts/local_validate.sh
+++ b/scripts/local_validate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+section() {
+  printf '\n==> %s\n' "$1"
+}
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'Missing required command: %s\n' "$1" >&2
+    exit 127
+  fi
+}
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+need actionlint
+need checkov
+need python3
+need ruby
+need terraform
+
+terraform_dirs=(
+  infra/envs/dev
+  infra/envs/dev-platform
+)
+
+for module_dir in infra/modules/aks infra/modules/network; do
+  if [ -d "$module_dir" ]; then
+    terraform_dirs+=("$module_dir")
+  fi
+done
+
+section "Tool versions"
+terraform version
+printf 'checkov %s\n' "$(checkov --version)"
+python3 -c 'import yaml; print(f"PyYAML {yaml.__version__}")'
+ruby --version
+actionlint -version
+
+section "YAML parse with PyYAML"
+python3 - <<'PY'
+from pathlib import Path
+import yaml
+
+paths = sorted(Path(".github/workflows").glob("*.yaml"))
+paths += sorted(Path(".github/workflows").glob("*.yml"))
+dependabot = Path(".github/dependabot.yml")
+if dependabot.exists():
+    paths.append(dependabot)
+
+for path in paths:
+    yaml.safe_load(path.read_text())
+    print(f"OK {path}")
+PY
+
+section "YAML parse with Ruby"
+ruby -e 'require "yaml"; (Dir[".github/workflows/*.{yaml,yml}"] + [".github/dependabot.yml"]).select { |p| File.exist?(p) }.sort.each { |p| YAML.load_file(p); puts "OK #{p}" }'
+
+section "GitHub Actions lint"
+actionlint -shellcheck= -color
+
+section "Terraform format"
+terraform fmt -check -recursive infra
+
+section "Terraform init and validate"
+for dir in "${terraform_dirs[@]}"; do
+  printf '\n-- %s\n' "$dir"
+  terraform -chdir="$dir" init -backend=false -input=false
+  terraform -chdir="$dir" validate
+done
+
+section "Checkov active Terraform roots"
+checkov -d infra/envs/dev --framework terraform --quiet
+checkov -d infra/envs/dev-platform --framework terraform --quiet
+
+section "Local validation complete"


### PR DESCRIPTION
## Summary
- Add `scripts/local_validate.sh` to run local workflow/Terraform/Checkov checks before pushing.
- Document the toolbox validation path in README and plan/TODO.
- Add a repo-backed starter Wiki page at `docs/wiki/Home.md` so Wiki content is reviewable before copying/syncing to GitHub Wiki.
- Refresh stale ROI planning notes now that issue #43 is already closed.

## ROI Decision
This is a low-cost developer-experience improvement: no Azure resources, no new paid services, and faster feedback before waiting for GitHub Actions. It keeps the GitHub Wiki as navigation only, with repo docs remaining the reviewed source of truth.

## Validation
- Installed/verified toolbox tools: Checkov `3.2.524`, PyYAML `6.0.3`, Ruby `3.4.8`, actionlint `1.7.12`.
- Ran `scripts/local_validate.sh` successfully from the `dev` toolbox.
- `git diff --check`
- GitHub Actions green on latest commit `f4aaf3c`: PR Quality Review

Closes #70