### PR TITLE
ci: skip Azure plan for Dependabot PRs

### DIFF
--- a/.github/workflows/tf-plan-apply.yaml
+++ b/.github/workflows/tf-plan-apply.yaml
@@ -27,6 +27,7 @@ env:
   ARM_SUBSCRIPTION_ID: "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
   ARM_TENANT_ID: "${{ secrets.AZURE_TENANT_ID }}"
   TF_TARGET_ENVS: ${{ vars.TF_TARGET_ENVS || '["dev","dev-platform"]' }}
+  IS_DEPENDABOT_PR: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
 
 jobs:
   terraform-plan:
@@ -56,7 +57,13 @@ jobs:
               ;;
           esac
 
+      - name: Skip cloud plan for Dependabot pull requests
+        if: env.IS_DEPENDABOT_PR == 'true'
+        run: |
+          echo "::notice::Skipping Azure OIDC Terraform plan for Dependabot. Dependabot PRs do not receive the normal Azure secrets; PR Quality Review and Terraform Unit Tests provide the low-cost validation path."
+
       - name: Azure OIDC Login
+        if: env.IS_DEPENDABOT_PR != 'true'
         uses: azure/login@v2
         with:
           client-id: ${{ env.ARM_CLIENT_ID }}
@@ -64,36 +71,44 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Setup Terraform
+        if: env.IS_DEPENDABOT_PR != 'true'
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
 
       - name: Terraform Init
+        if: env.IS_DEPENDABOT_PR != 'true'
         run: terraform -chdir=${{ env.TF_ENV_DIR }} init -input=false
 
       - name: Terraform Format
+        if: env.IS_DEPENDABOT_PR != 'true'
         run: terraform -chdir=${{ env.TF_ENV_DIR }} fmt -check
 
       - name: Terraform Validate
+        if: env.IS_DEPENDABOT_PR != 'true'
         run: terraform -chdir=${{ env.TF_ENV_DIR }} validate
 
       # -------- TFLint --------
       # Lint Terraform with TFLint on PRs
       - name: Set up TFLint
+        if: env.IS_DEPENDABOT_PR != 'true'
         uses: terraform-linters/setup-tflint@v4
         with:
           tflint_version: v0.59.1   # Use >=0.54.0 where `call_module_type` is supported
 
       - name: TFLint init (download plugins/rulesets)
+        if: env.IS_DEPENDABOT_PR != 'true'
         run: tflint --init
         working-directory: ${{ env.TF_ENV_DIR }}
 
       - name: TFLint run (recursive, local modules only)
+        if: env.IS_DEPENDABOT_PR != 'true'
         run: tflint --recursive --call-module-type=local
         working-directory: ${{ env.TF_ENV_DIR }}
 
       # -------- tfsec (security) --------
       - name: Run tfsec
+        if: env.IS_DEPENDABOT_PR != 'true'
         uses: aquasecurity/tfsec-action@v1.0.0
         with:
           working_directory: ${{ env.TF_ENV_DIR }}
@@ -102,6 +117,7 @@ jobs:
 
       # -------- Plan --------
       - name: Terraform Plan
+        if: env.IS_DEPENDABOT_PR != 'true'
         id: tf-plan
         run: |
           set +e
@@ -118,6 +134,7 @@ jobs:
           fi
 
       - name: Upload plan artifact
+        if: env.IS_DEPENDABOT_PR != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: tfplan-${{ matrix.environment }}
@@ -127,6 +144,7 @@ jobs:
           if-no-files-found: error
 
       - name: Plan Summary
+        if: env.IS_DEPENDABOT_PR != 'true'
         id: tfplan-summary
         run: |
           sudo apt-get update >/dev/null && sudo apt-get install -y jq >/dev/null
@@ -143,12 +161,13 @@ jobs:
           echo "summary=$SUMMARY" >> $GITHUB_OUTPUT
 
       - name: Publish Plan to Summary
+        if: env.IS_DEPENDABOT_PR != 'true'
         run: |
           echo "## Terraform Plan Summary (${{ matrix.environment }})" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.tfplan-summary.outputs.summary }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.IS_DEPENDABOT_PR != 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Configuration details and examples will be documented as features are implemente
 - GitHub Terraform workflows now target both `dev` and `dev-platform` by default, so future AKS Terraform changes can be planned/applied from Actions as well. Drift detection also checks both roots, keeps drift issues environment-specific, and publishes count summaries instead of full Terraform plans in issues.
 - Terraform workflow guardrails now reject unsupported matrix environments before Azure login. Manual destroy defaults to `dev-platform`; destroying the `dev` bootstrap/state root requires an extra bootstrap confirmation phrase.
 - Terraform workflows are ready for split Azure OIDC identities: `AZURE_PLAN_CLIENT_ID` for plan/drift, `AZURE_APPLY_CLIENT_ID` for apply/destroy, and `AZURE_CLIENT_ID` only as a legacy fallback during migration.
-- PR review guardrails now include a static, no-Azure-login quality workflow for GitHub Actions syntax (`actionlint`) and Terraform `fmt/init/validate`, plus Dependabot PRs for GitHub Actions and Terraform provider updates.
+- PR review guardrails now include a static, no-Azure-login quality workflow for GitHub Actions syntax (`actionlint`) and Terraform `fmt/init/validate`, plus Dependabot PRs for GitHub Actions and Terraform provider updates. Dependabot pull requests intentionally skip Azure OIDC Terraform plans because Dependabot does not receive the normal Azure secrets; static PR Quality Review and Terraform Unit Tests are the low-cost validation path for those bumps.
 - The current cost-aware demo default for AKS nodes is `Standard_D2as_v5`, not `Standard_D2_v2`. That is the current best-ROI middle ground: materially cheaper than Dv2, more modern, and less memory-constrained than the ultra-cheap `A2_v2` candidate.
 - B-series was not chosen for the demo default because Microsoft documents B-series VMs as unsupported for AKS system node pools.
 - The first demo AKS cluster originally kept local accounts enabled because disabling them on Kubernetes 1.25+ requires managed Entra ID integration. Issue `#52` wired that managed Entra path into Terraform so the next AKS-enabled apply can keep `local_account_disabled` on deliberately instead of by demo shortcut.
@@ -166,6 +166,8 @@ flatpak-spawn --host toolbox run -c dev bash -lc 'cd /var/home/maxmanus/Dokument
 ```
 
 The helper checks the same low-cost path we care about locally: workflow YAML parsing, `actionlint`, Terraform format/init/validate, and Checkov scans for the active Terraform roots. The expected toolbox tools are Terraform, Checkov, PyYAML, Ruby, and actionlint.
+
+Running GitHub Actions locally is only partial. Use `scripts/local_validate.sh` for the reliable local signal; tools such as `act` can emulate some workflow shell steps, but they do not faithfully prove GitHub OIDC, repository secrets, SARIF upload permissions, branch protections, or hosted-runner behavior.
 
 The GitHub Wiki should stay a navigation layer, not a second source of truth. A starter Wiki page is tracked at [docs/wiki/Home.md](docs/wiki/Home.md) so changes remain reviewable before being copied or synced to the GitHub Wiki.
 

--- a/plan.md
+++ b/plan.md
@@ -28,13 +28,14 @@
    - Runs Terraform init/fmt/validate/plan under `infra/envs/<env>` using `-chdir`.
    - Executes TFLint/tfsec scoped to the same directory.
    - Uploads the per-environment plan artifact and computed exit code.
-3. Apply jobs download the matching artifact, inspect the exit code, and only run `terraform apply` when changes exist and the branch is `main`.
-4. `tf-drift` now runs in matrix mode for `dev` and `dev-platform`, uses Azure OIDC login, creates or closes environment-specific drift issues, and publishes redacted count summaries instead of full plan text in issues.
-5. `pr-quality.yaml` provides static automated PR review without Azure login: workflow linting via `actionlint` plus Terraform `fmt/init/validate` over the active roots/modules.
-6. Dependabot is enabled for GitHub Actions and Terraform provider updates so dependency bumps arrive as reviewable PRs instead of silent drift.
-7. `tf-unit-tests.yaml` now validates the live `dev` root, `dev-platform`, and local modules, and Checkov SARIF now covers both active roots.
-8. `tf-destroy.yaml` provides a guarded manual destroy path for cost-control or teardown scenarios. Destroy defaults to `dev-platform`; destroying `dev` requires an extra bootstrap/state confirmation phrase.
-9. `scripts/local_validate.sh` mirrors the low-cost local checks before push: YAML parsing, `actionlint`, Terraform format/init/validate, and Checkov for the active Terraform roots.
+3. Dependabot pull requests intentionally skip the Azure OIDC Terraform plan path because Dependabot does not receive the normal Azure secrets. Static PR Quality Review and Terraform Unit Tests remain the low-cost validation signal for dependency bumps.
+4. Apply jobs download the matching artifact, inspect the exit code, and only run `terraform apply` when changes exist and the branch is `main`.
+5. `tf-drift` now runs in matrix mode for `dev` and `dev-platform`, uses Azure OIDC login, creates or closes environment-specific drift issues, and publishes redacted count summaries instead of full plan text in issues.
+6. `pr-quality.yaml` provides static automated PR review without Azure login: workflow linting via `actionlint` plus Terraform `fmt/init/validate` over the active roots/modules.
+7. Dependabot is enabled for GitHub Actions and Terraform provider updates so dependency bumps arrive as reviewable PRs instead of silent drift.
+8. `tf-unit-tests.yaml` now validates the live `dev` root, `dev-platform`, and local modules, and Checkov SARIF now covers both active roots.
+9. `tf-destroy.yaml` provides a guarded manual destroy path for cost-control or teardown scenarios. Destroy defaults to `dev-platform`; destroying `dev` requires an extra bootstrap/state confirmation phrase.
+10. `scripts/local_validate.sh` mirrors the low-cost local checks before push: YAML parsing, `actionlint`, Terraform format/init/validate, and Checkov for the active Terraform roots.
 
 ## Security Hardening Status (Dev)
 | Control | Status | Notes |
@@ -56,10 +57,11 @@
 2. Keep AKS disabled in `infra/envs/dev`; the bootstrap root should not silently grow into the long-term platform root.
 3. Keep AKS disabled by default for cost control unless there is an active demo/learning session and a clear teardown plan.
 4. Watch the first scheduled/manual drift run from merged PR `#59` to confirm separate drift issues per environment.
-5. Configure split Azure identities in GitHub secrets when ready: `AZURE_PLAN_CLIENT_ID` for plan/drift and `AZURE_APPLY_CLIENT_ID` for apply/destroy.
-6. After split identities are proven, remove the legacy `AZURE_CLIENT_ID` fallback from Terraform workflows.
-7. Continue stale issue hygiene for delivered workflow/bootstrap work if GitHub has not already caught up.
-8. Then revisit additional dev hardening upgrades such as SAS policy, CMK, private endpoints, or GRS.
+5. Merge the local validation / Dependabot guard PR, then use it to triage Dependabot bumps locally before spending GitHub Actions minutes.
+6. Configure split Azure identities in GitHub secrets when ready: `AZURE_PLAN_CLIENT_ID` for plan/drift and `AZURE_APPLY_CLIENT_ID` for apply/destroy.
+7. After split identities are proven, remove the legacy `AZURE_CLIENT_ID` fallback from Terraform workflows.
+8. Continue stale issue hygiene for delivered workflow/bootstrap work if GitHub has not already caught up.
+9. Then revisit additional dev hardening upgrades such as SAS policy, CMK, private endpoints, or GRS.
 
 ## ROI Priority Order (2026-04-25)
 

--- a/scripts/local_validate.sh
+++ b/scripts/local_validate.sh
@@ -15,6 +15,11 @@ need() {
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 cd "$ROOT_DIR"
 
+# Keep Azure CLI session writes out of sandboxed or read-only home directories.
+export AZURE_CONFIG_DIR="${AZURE_CONFIG_DIR:-${TMPDIR:-/tmp}/chatops-guard-azure-cli}"
+mkdir -p "$AZURE_CONFIG_DIR"
+TF_DATA_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/chatops-guard-tfdata.XXXXXX")"
+
 need actionlint
 need checkov
 need python3
@@ -67,8 +72,10 @@ terraform fmt -check -recursive infra
 section "Terraform init and validate"
 for dir in "${terraform_dirs[@]}"; do
   printf '\n-- %s\n' "$dir"
-  terraform -chdir="$dir" init -backend=false -input=false
-  terraform -chdir="$dir" validate
+  tf_data_dir="${TF_DATA_ROOT}/${dir//\//_}"
+  mkdir -p "$tf_data_dir"
+  TF_DATA_DIR="$tf_data_dir" terraform -chdir="$dir" init -backend=false -input=false
+  TF_DATA_DIR="$tf_data_dir" terraform -chdir="$dir" validate
 done
 
 section "Checkov active Terraform roots"


### PR DESCRIPTION
## Summary
- Skip the Azure OIDC Terraform plan path when the PR actor is `dependabot[bot]`.
- Keep normal non-Dependabot PRs and `main` on the existing Terraform plan/apply path.
- Make `scripts/local_validate.sh` more reliable locally by isolating Azure CLI config and Terraform data under temporary directories.
- Document why local validation is the reliable low-cost path and why full GitHub Actions can only be partially emulated locally.

## ROI Decision
This reduces noisy Dependabot failures and wasted GitHub Actions minutes without granting Dependabot Azure credentials. Static validation remains the right signal for dependency bumps; real Azure plans remain reserved for normal PRs and `main`.

## Validation
- `scripts/local_validate.sh`
- `git diff --check`

Closes #72