### PR TITLE
Add Trivy IaC security gate

### DIFF
--- a/.github/workflows/pr-quality.yaml
+++ b/.github/workflows/pr-quality.yaml
@@ -75,9 +75,13 @@ jobs:
           dirs=(
             infra/envs/dev
             infra/envs/dev-platform
-            infra/modules/aks
-            infra/modules/network
           )
+
+          for module_dir in infra/modules/*; do
+            if [ -d "${module_dir}" ] && find "${module_dir}" -maxdepth 1 -name '*.tf' -print -quit | grep -q .; then
+              dirs+=("${module_dir}")
+            fi
+          done
 
           for dir in "${dirs[@]}"; do
             echo "::group::${dir}"

--- a/.github/workflows/tf-unit-tests.yaml
+++ b/.github/workflows/tf-unit-tests.yaml
@@ -44,8 +44,8 @@ jobs:
     - name: Terraform Init
       run: |
         dirs="infra/envs/dev infra/envs/dev-platform"
-        for module_dir in infra/modules/aks infra/modules/network; do
-          if [ -d "$module_dir" ]; then
+        for module_dir in infra/modules/*; do
+          if [ -d "$module_dir" ] && find "$module_dir" -maxdepth 1 -name '*.tf' -print -quit | grep -q .; then
             dirs="$dirs $module_dir"
           fi
         done
@@ -56,8 +56,8 @@ jobs:
     - name: Terraform Validate
       run: |
         dirs="infra/envs/dev infra/envs/dev-platform"
-        for module_dir in infra/modules/aks infra/modules/network; do
-          if [ -d "$module_dir" ]; then
+        for module_dir in infra/modules/*; do
+          if [ -d "$module_dir" ] && find "$module_dir" -maxdepth 1 -name '*.tf' -print -quit | grep -q .; then
             dirs="$dirs $module_dir"
           fi
         done
@@ -68,8 +68,8 @@ jobs:
     - name: Terraform Format
       run: |
         dirs="infra/envs/dev infra/envs/dev-platform"
-        for module_dir in infra/modules/aks infra/modules/network; do
-          if [ -d "$module_dir" ]; then
+        for module_dir in infra/modules/*; do
+          if [ -d "$module_dir" ] && find "$module_dir" -maxdepth 1 -name '*.tf' -print -quit | grep -q .; then
             dirs="$dirs $module_dir"
           fi
         done
@@ -110,3 +110,32 @@ jobs:
       with:
         sarif_file: results.sarif
         category: checkov-${{ matrix.target.name }}
+
+  trivy-iac:
+    name: 'Trivy IaC'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    # Trivy complements Checkov with a second IaC scanner. Image scanning is
+    # deferred until this repo has a real Docker/ACR build path.
+    - name: Run Trivy IaC scan
+      uses: aquasecurity/trivy-action@v0.36.0
+      with:
+        scan-type: config
+        scan-ref: infra
+        hide-progress: true
+        format: sarif
+        output: trivy-results.sarif
+        exit-code: '1'
+        severity: CRITICAL,HIGH
+        limit-severities-for-sarif: true
+
+    - name: Upload Trivy SARIF file
+      if: always()
+      uses: github/codeql-action/upload-sarif@v4
+      with:
+        sarif_file: trivy-results.sarif
+        category: trivy-iac

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Configuration details and examples will be documented as features are implemente
 - GitHub Terraform workflows now target both `dev` and `dev-platform` by default, so future AKS Terraform changes can be planned/applied from Actions as well. Drift detection also checks both roots, keeps drift issues environment-specific, and publishes count summaries instead of full Terraform plans in issues.
 - Terraform workflow guardrails now reject unsupported matrix environments before Azure login. Manual destroy defaults to `dev-platform`; destroying the `dev` bootstrap/state root requires an extra bootstrap confirmation phrase.
 - Terraform workflows are ready for split Azure OIDC identities: `AZURE_PLAN_CLIENT_ID` for plan/drift, `AZURE_APPLY_CLIENT_ID` for apply/destroy, and `AZURE_CLIENT_ID` only as a legacy fallback during migration.
-- PR review guardrails now include a static, no-Azure-login quality workflow for GitHub Actions syntax (`actionlint`) and Terraform `fmt/init/validate`, plus Dependabot PRs for GitHub Actions and Terraform provider updates. Dependabot pull requests intentionally skip Azure OIDC Terraform plans because Dependabot does not receive the normal Azure secrets; static PR Quality Review and Terraform Unit Tests are the low-cost validation path for those bumps.
+- PR review guardrails now include a static, no-Azure-login quality workflow for GitHub Actions syntax (`actionlint`) and Terraform `fmt/init/validate`, plus Dependabot PRs for GitHub Actions and Terraform provider updates. Terraform Unit Tests also run Checkov and Trivy IaC scanning with SARIF upload. Dependabot pull requests intentionally skip Azure OIDC Terraform plans because Dependabot does not receive the normal Azure secrets; static PR Quality Review and Terraform Unit Tests are the low-cost validation path for those bumps.
 - The current cost-aware demo default for AKS nodes is `Standard_D2as_v5`, not `Standard_D2_v2`. That is the current best-ROI middle ground: materially cheaper than Dv2, more modern, and less memory-constrained than the ultra-cheap `A2_v2` candidate.
 - B-series was not chosen for the demo default because Microsoft documents B-series VMs as unsupported for AKS system node pools.
 - The first demo AKS cluster originally kept local accounts enabled because disabling them on Kubernetes 1.25+ requires managed Entra ID integration. Issue `#52` wired that managed Entra path into Terraform so the next AKS-enabled apply can keep `local_account_disabled` on deliberately instead of by demo shortcut.
@@ -138,6 +138,7 @@ Configuration details and examples will be documented as features are implemente
   - Checkov skips in dev (documented inline in `infra/envs/dev/main.tf`) due to budget/complexity:
     - CKV2_AZURE_1 (CMK), CKV_AZURE_206 (GRS replication), CKV_AZURE_59 (public network), CKV2_AZURE_33 (private endpoint).
     - CKV_AZURE_33 (queue logging), CKV2_AZURE_21 (blob read logging).
+  - Trivy skip in dev: AVD-AZU-0012 is ignored for the same documented state-backend public network tradeoff until a private runner or private endpoint path exists.
 - Budget-conscious items still pending for dev (tracked in [plan.md](plan.md)):
   - Geo-redundant replication (CKV_AZURE_206) intentionally left as LRS to minimize cost.
   - Customer-managed keys (CKV2_AZURE_1), SAS expiration policy (CKV2_AZURE_41), and private endpoints (CKV2_AZURE_33) are deferred until prod hardening.
@@ -167,7 +168,7 @@ From the Flatpak/toolbox setup used for this project:
 flatpak-spawn --host toolbox run -c dev bash -lc 'cd /var/home/maxmanus/Dokumente/Coding/chatops-guard && scripts/local_validate.sh'
 ```
 
-The helper checks the same low-cost path we care about locally: workflow YAML parsing, `actionlint`, Terraform format/init/validate, and Checkov scans for the active Terraform roots. The expected toolbox tools are Terraform, Checkov, PyYAML, Ruby, and actionlint.
+The helper checks the same low-cost path we care about locally: workflow YAML parsing, `actionlint`, Terraform format/init/validate, and Checkov scans for the active Terraform roots. The expected toolbox tools are Terraform, Checkov, PyYAML, Ruby, and actionlint. Trivy IaC scanning currently runs in GitHub Actions; make it part of `scripts/local_validate.sh` after Trivy is installed in the local toolbox.
 
 Running GitHub Actions locally is only partial. Use `scripts/local_validate.sh` for the reliable local signal; tools such as `act` can emulate some workflow shell steps, but they do not faithfully prove GitHub OIDC, repository secrets, SARIF upload permissions, branch protections, or hosted-runner behavior.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -78,6 +78,10 @@ This file is a grouped planning view of the current backlog after the recent boo
   - [x] #70 DEVX-01 · Add local validation runner and Wiki starter docs
   - [ ] After split Azure identities are proven, remove the legacy `AZURE_CLIENT_ID` fallback from Terraform workflows
   - [ ] #28 SEC-01 · Trivy image + IaC scan gate
+  - [x] Add Trivy IaC/config scanning with SARIF upload to Terraform Unit Tests
+  - [x] Make Terraform CI module validation discover `infra/modules/*` so new modules such as `event-grid` are covered automatically
+  - [ ] Add Trivy image scanning after `#31` creates a real Docker/ACR build path
+  - [ ] Install Trivy in the local toolbox and mirror the CI scan in `scripts/local_validate.sh`
   - [ ] #30 SEC-03 · SBOM generation & upload
   - [ ] #31 CI-01 · Build & push images to ACR
   - [ ] #8 Secure ACR Images when they are available

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -37,6 +37,10 @@ This mirrors the low-cost CI checks where practical: YAML parsing, actionlint,
 Terraform format/init/validate, and Checkov scans for the active Terraform
 roots.
 
+GitHub Terraform Unit Tests additionally run Trivy IaC scanning and upload SARIF
+results. Image scanning is intentionally deferred until the repo has a real
+Docker/ACR build path.
+
 ## Wiki Policy
 
 Do not let the Wiki become a second source of truth. Use it as a lightweight

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -31,6 +31,7 @@ resource "azurerm_resource_group" "state" {
   location = var.location      # eg "westeurope"
 }
 
+#trivy:ignore:AVD-AZU-0012
 resource "azurerm_storage_account" "state" {
   # checkov:skip=CKV2_AZURE_1: CMK deferred in dev to avoid Key Vault cost/overhead
   # checkov:skip=CKV_AZURE_206: LRS kept intentionally for budget-friendly dev state

--- a/plan.md
+++ b/plan.md
@@ -35,9 +35,9 @@
 5. `tf-drift` now runs in matrix mode for `dev` and `dev-platform`, uses Azure OIDC login, creates or closes environment-specific drift issues, and publishes redacted count summaries instead of full plan text in issues.
 6. `pr-quality.yaml` provides static automated PR review without Azure login: workflow linting via `actionlint` plus Terraform `fmt/init/validate` over the active roots/modules.
 7. Dependabot is enabled for GitHub Actions and Terraform provider updates so dependency bumps arrive as reviewable PRs instead of silent drift.
-8. `tf-unit-tests.yaml` now validates the live `dev` root, `dev-platform`, and local modules, and Checkov SARIF now covers both active roots.
+8. `tf-unit-tests.yaml` now validates the live `dev` root, `dev-platform`, and local modules, and Checkov plus Trivy SARIF now cover the active IaC surface.
 9. `tf-destroy.yaml` provides a guarded manual destroy path for cost-control or teardown scenarios. Destroy defaults to `dev-platform`; destroying `dev` requires an extra bootstrap/state confirmation phrase.
-10. `scripts/local_validate.sh` mirrors the low-cost local checks before push: YAML parsing, `actionlint`, Terraform format/init/validate, and Checkov for the active Terraform roots.
+10. `scripts/local_validate.sh` mirrors the low-cost local checks before push: YAML parsing, `actionlint`, Terraform format/init/validate, and Checkov for the active Terraform roots. Trivy remains CI-only until the local toolbox has the binary installed.
 
 ## Security Hardening Status (Dev)
 | Control | Status | Notes |
@@ -48,6 +48,7 @@
 | Diagnostics to Log Analytics | ✅ | Dev LA workspace with 30-day retention; diagnostics now target the blob service scope Azure actually supports. |
 | Blob versioning | ✅ | Kept enabled on the dev state account to improve tfstate recovery; extra blob storage cost should stay modest for this small dev backend. |
 | Checkov skips (dev) | ⚠️ | CKV2_AZURE_1, CKV_AZURE_206, CKV_AZURE_59, CKV2_AZURE_33, CKV_AZURE_33, CKV2_AZURE_21 (documented inline). |
+| Trivy skip (dev) | ⚠️ | AVD-AZU-0012 is the same intentional public-network state-backend tradeoff as the Checkov public network skip. |
 | AKS subnet NSG | ✅ | `infra/modules/network` associates the AKS node subnet with a minimal NSG; no broad inbound rules are added. |
 | Event Grid local auth | ✅ | The first custom topic disables local key auth so future publishing can use Entra ID/RBAC instead of shared keys. |
 | Event Grid public access | ✅ | Public network access is disabled on the first topic; the later event-pipeline work must deliberately choose private endpoint or a temporary dev publishing exception. |
@@ -56,6 +57,7 @@
 | Customer-managed keys | ⏳ | Requires Key Vault + key rotation; deferred for cost reasons. |
 | Private endpoints | ⏳ | Adds VNets/DNS and billing overhead; hold until prod readiness. |
 | Geo-redundant replication | ⏳ | LRS kept for budget; document justification in code comment. |
+| Trivy IaC scan gate | ✅ | Added to Terraform Unit Tests as a second IaC scanner with SARIF upload; image scanning is deferred until container images exist. |
 
 ## Next Steps
 1. Refresh local Azure auth with `az login` before making any live cost claim about AKS or VMSS resources.
@@ -65,8 +67,9 @@
 5. Apply the issue `#16` Event Grid topic from `dev-platform`, then keep later subscriptions/queue/summariser work in separate PRs.
 6. Configure split Azure identities in GitHub secrets when ready: `AZURE_PLAN_CLIENT_ID` for plan/drift and `AZURE_APPLY_CLIENT_ID` for apply/destroy.
 7. After split identities are proven, remove the legacy `AZURE_CLIENT_ID` fallback from Terraform workflows.
-8. Continue stale issue hygiene for delivered workflow/bootstrap work if GitHub has not already caught up.
-9. Then revisit additional dev hardening upgrades such as SAS policy, CMK, private endpoints, or GRS.
+8. Install Trivy in the local toolbox and add it to `scripts/local_validate.sh` after confirming the same findings as CI.
+9. Continue stale issue hygiene for delivered workflow/bootstrap work if GitHub has not already caught up.
+10. Then revisit additional dev hardening upgrades such as SAS policy, CMK, private endpoints, or GRS.
 
 ## ROI Priority Order (2026-04-25)
 

--- a/scripts/local_validate.sh
+++ b/scripts/local_validate.sh
@@ -19,6 +19,7 @@ cd "$ROOT_DIR"
 export AZURE_CONFIG_DIR="${AZURE_CONFIG_DIR:-${TMPDIR:-/tmp}/chatops-guard-azure-cli}"
 mkdir -p "$AZURE_CONFIG_DIR"
 TF_DATA_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/chatops-guard-tfdata.XXXXXX")"
+trap 'rm -rf "$TF_DATA_ROOT"' EXIT
 
 need actionlint
 need checkov


### PR DESCRIPTION
## Summary

Refs #28.

This PR adds the Terraform/IaC Trivy slice for issue #28. The app image scan now lives in the summariser app workflow, so this PR stays focused on static infrastructure scanning.

## What Changed

- Adds a Trivy IaC/config SARIF job to Terraform Unit Tests, scoped to `infra`.
- Keeps this PR focused on IaC scanning; container image scanning is handled separately by `app-summariser.yaml`.
- Makes Terraform CI module validation discover `infra/modules/*` so new modules like `event-grid` are covered automatically.
- Documents the dev state storage public-network Trivy exception as the same budget/CI reachability tradeoff already documented for Checkov.
- Adds cleanup for temporary Terraform data directories in `scripts/local_validate.sh`.
- Adds Trivy IaC scanning to `scripts/local_validate.sh` so the same security gate can be checked before pushing.

## Validation

- `scripts/local_validate.sh`
- `git diff --check`
- GitHub Actions on `86940cc`: PR Quality Review, Terraform Unit Tests, Terraform Plan/Apply all passed

## Learning / ROI Note

This is a low-cloud-cost security improvement: it adds another static IaC scanner without creating Azure resources. The ROI is high because failures move earlier: local validation catches Trivy/Checkov/Terraform issues before we spend GitHub Actions time or create Azure resources.