### PR TITLE
Add FastAPI summariser image skeleton

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,10 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 3
+
+  - package-ecosystem: "pip"
+    directory: "/apps/summariser"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3

--- a/.github/workflows/app-summariser.yaml
+++ b/.github/workflows/app-summariser.yaml
@@ -1,0 +1,64 @@
+name: 'Summariser App CI'
+
+on:
+  push:
+    paths:
+      - 'apps/summariser/**'
+      - '.github/workflows/app-summariser.yaml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'apps/summariser/**'
+      - '.github/workflows/app-summariser.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: app-summariser-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-build-scan:
+    name: 'Test, Build, Scan'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: apps/summariser/pyproject.toml
+
+      - name: Install test dependencies
+        run: python -m pip install -e 'apps/summariser[test]'
+
+      - name: Run tests
+        run: pytest apps/summariser
+
+      - name: Build image
+        run: docker build -t chatops-guard/summariser:${{ github.sha }} apps/summariser
+
+      - name: Run Trivy image scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: chatops-guard/summariser:${{ github.sha }}
+          format: sarif
+          output: trivy-summariser-image.sarif
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
+
+      - name: Upload Trivy SARIF file
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-summariser-image.sarif
+          category: trivy-summariser-image

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,14 @@ infra/modules/**/.terraform.lock.hcl
 .terraformrc
 terraform.rc
 **/.local/*
+
+# Python local test/build artifacts
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.venv/
+dist/
+build/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Configuration details and examples will be documented as features are implemente
   - the blob-service diagnostic setting that sends storage logs/metrics to Log Analytics
 - `infra/modules/aks` now exists as the first reusable platform module, and `infra/envs/dev-platform` is the first thin non-bootstrap root that composes it. That root now has its own backend/state, has safely applied `rg-chatops-guard-platform-dev` plus a minimal VNet/subnet foundation, and can produce a real `enable_aks = true` plan while AKS still stays explicitly gated by default. The AKS node subnet is associated with a minimal NSG owned by `infra/modules/network`; no broad inbound rules are added. When AKS is enabled there, `api_server_authorized_ip_ranges` must also be set so the first demo cluster does not leave its public API open unintentionally.
 - `infra/modules/event-grid` provides the first event-ingestion building block: one Basic/Event Grid custom topic in `dev-platform`. This is intentionally topic-only for issue `#16`; subscriptions, queues, consumers, and summariser wiring belong to later event-pipeline work.
+- `apps/summariser` is the first application skeleton: a minimal FastAPI service with `/healthz` and `/summarise` endpoints. It is intentionally rule-based for now so Docker build, Trivy image scan, and future ACR push can be proven before adding Azure OpenAI cost or secrets.
 - The first AKS rollout path was intentionally local-first to prove the cluster create with an untracked `infra/envs/dev-platform/terraform.tfvars` and a local `/32` admin IP.
 - GitHub Terraform workflows now target both `dev` and `dev-platform` by default, so future AKS Terraform changes can be planned/applied from Actions as well. Drift detection also checks both roots, keeps drift issues environment-specific, and publishes count summaries instead of full Terraform plans in issues.
 - Terraform workflow guardrails now reject unsupported matrix environments before Azure login. Manual destroy defaults to `dev-platform`; destroying the `dev` bootstrap/state root requires an extra bootstrap confirmation phrase.
@@ -167,7 +168,13 @@ From the Flatpak/toolbox setup used for this project:
 flatpak-spawn --host toolbox run -c dev bash -lc 'cd /var/home/maxmanus/Dokumente/Coding/chatops-guard && scripts/local_validate.sh'
 ```
 
-The helper checks the same low-cost path we care about locally: workflow YAML parsing, `actionlint`, Terraform format/init/validate, and Checkov scans for the active Terraform roots. The expected toolbox tools are Terraform, Checkov, PyYAML, Ruby, and actionlint.
+The helper checks the same low-cost path we care about locally: workflow YAML parsing, `actionlint`, Terraform format/init/validate, Checkov scans for the active Terraform roots, and the summariser unit tests. The expected toolbox tools are Terraform, Checkov, PyYAML, Ruby, pytest, and actionlint.
+
+For local container checks, use the host Podman engine:
+
+```bash
+flatpak-spawn --host podman build --format docker -t chatops-guard/summariser:local apps/summariser
+```
 
 Running GitHub Actions locally is only partial. Use `scripts/local_validate.sh` for the reliable local signal; tools such as `act` can emulate some workflow shell steps, but they do not faithfully prove GitHub OIDC, repository secrets, SARIF upload permissions, branch protections, or hosted-runner behavior.
 

--- a/apps/summariser/.dockerignore
+++ b/apps/summariser/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.venv/
+dist/
+build/
+*.egg-info/
+

--- a/apps/summariser/Dockerfile
+++ b/apps/summariser/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.13-alpine
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN addgroup -S app && adduser -S -G app -h /app app
+
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+RUN pip install --no-cache-dir --root-user-action=ignore .
+
+USER app
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/healthz', timeout=2).read()"
+
+CMD ["uvicorn", "chatops_guard_summariser.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/apps/summariser/README.md
+++ b/apps/summariser/README.md
@@ -1,0 +1,42 @@
+# ChatOps Guard Summariser
+
+Minimal FastAPI service for turning raw ChatOps, AKS, or Azure signals into a
+short operator-facing summary.
+
+This is intentionally a rule-based skeleton first. Azure OpenAI, LangChain,
+Event Grid subscriptions, queues, and Slack delivery are later slices.
+
+## API
+
+- `GET /healthz`: liveness check for CI, containers, and Kubernetes probes.
+- `POST /summarise`: accepts one signal and returns a first-pass summary,
+  impact, and next action.
+
+Example request:
+
+```json
+{
+  "source": "aks",
+  "severity": "warning",
+  "title": "Readiness probe failures",
+  "message": "Pod api-7d9f failed readiness probe 12 times in namespace dev",
+  "resource": "pod/api-7d9f"
+}
+```
+
+## Local Test
+
+```bash
+PYTHONPATH=apps/summariser/src pytest apps/summariser/tests
+```
+
+## Container Build
+
+From the host setup used for this project:
+
+```bash
+flatpak-spawn --host podman build --format docker -t chatops-guard/summariser:local apps/summariser
+```
+
+`--format docker` keeps Docker-style image metadata such as `HEALTHCHECK`
+available when building with Podman.

--- a/apps/summariser/pyproject.toml
+++ b/apps/summariser/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "chatops-guard-summariser"
+version = "0.1.0"
+description = "FastAPI service that summarises ChatOps Guard signals."
+requires-python = ">=3.12"
+dependencies = [
+  "fastapi>=0.115,<1.0",
+  "uvicorn[standard]>=0.32,<1.0",
+]
+
+[project.optional-dependencies]
+test = [
+  "httpx>=0.27,<1.0",
+  "pytest>=8,<9",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
+

--- a/apps/summariser/src/chatops_guard_summariser/__init__.py
+++ b/apps/summariser/src/chatops_guard_summariser/__init__.py
@@ -1,0 +1,6 @@
+"""ChatOps Guard summariser service."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"
+

--- a/apps/summariser/src/chatops_guard_summariser/main.py
+++ b/apps/summariser/src/chatops_guard_summariser/main.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+
+from .models import Signal, SummaryResponse
+from .service import summarise_signal
+
+app = FastAPI(
+    title="ChatOps Guard Summariser",
+    version="0.1.0",
+    description="Turns raw operational signals into short operator-facing summaries.",
+)
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok", "service": "summariser"}
+
+
+@app.post("/summarise", response_model=SummaryResponse)
+def summarise(signal: Signal) -> SummaryResponse:
+    return SummaryResponse(**summarise_signal(signal.model_dump()))
+

--- a/apps/summariser/src/chatops_guard_summariser/models.py
+++ b/apps/summariser/src/chatops_guard_summariser/models.py
@@ -1,0 +1,21 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+Severity = Literal["info", "warning", "error", "critical"]
+
+
+class Signal(BaseModel):
+    source: str = Field(..., min_length=1, max_length=80)
+    severity: Severity = "info"
+    title: str | None = Field(default=None, max_length=160)
+    message: str = Field(..., min_length=1, max_length=4000)
+    resource: str | None = Field(default=None, max_length=200)
+
+
+class SummaryResponse(BaseModel):
+    summary: str
+    impact: str
+    next_action: str
+    mode: Literal["rule_based_stub"] = "rule_based_stub"
+

--- a/apps/summariser/src/chatops_guard_summariser/service.py
+++ b/apps/summariser/src/chatops_guard_summariser/service.py
@@ -1,0 +1,59 @@
+from collections.abc import Mapping
+from typing import Any
+
+IMPACT_BY_SEVERITY = {
+    "critical": "User-facing or automation-impacting failure is likely.",
+    "error": "A component may be failing and needs operator attention.",
+    "warning": "The system may be degraded or close to an operational threshold.",
+    "info": "Informational signal; no immediate impact is known.",
+}
+
+NEXT_ACTION_BY_SEVERITY = {
+    "critical": "Check the affected resource immediately and prepare rollback or mitigation.",
+    "error": "Inspect recent logs, deployment changes, and resource health.",
+    "warning": "Watch the signal and check configuration before it becomes an incident.",
+    "info": "Record the signal and continue monitoring.",
+}
+
+
+def summarise_signal(signal: Mapping[str, Any]) -> dict[str, str]:
+    source = _clean(signal.get("source")) or "unknown-source"
+    severity = (_clean(signal.get("severity")) or "info").lower()
+    title = _clean(signal.get("title"))
+    message = _clean(signal.get("message")) or "No message supplied."
+    resource = _clean(signal.get("resource"))
+
+    if severity not in IMPACT_BY_SEVERITY:
+        severity = "info"
+
+    headline = title or _first_sentence(message)
+    summary = f"{source} reported {severity}: {headline}"
+    if resource:
+        summary = f"{summary} ({resource})"
+
+    return {
+        "summary": _shorten(summary, 240),
+        "impact": IMPACT_BY_SEVERITY[severity],
+        "next_action": NEXT_ACTION_BY_SEVERITY[severity],
+        "mode": "rule_based_stub",
+    }
+
+
+def _clean(value: Any) -> str:
+    if value is None:
+        return ""
+    return " ".join(str(value).split())
+
+
+def _first_sentence(message: str) -> str:
+    for separator in (".", "!", "?"):
+        if separator in message:
+            return message.split(separator, 1)[0]
+    return message
+
+
+def _shorten(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return f"{value[: limit - 1].rstrip()}…"
+

--- a/apps/summariser/tests/test_api_contract.py
+++ b/apps/summariser/tests/test_api_contract.py
@@ -1,0 +1,38 @@
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+from chatops_guard_summariser.main import app
+
+
+def test_healthz_returns_ok() -> None:
+    client = TestClient(app)
+
+    response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "service": "summariser"}
+
+
+def test_summarise_returns_operator_friendly_shape() -> None:
+    client = TestClient(app)
+
+    response = client.post(
+        "/summarise",
+        json={
+            "source": "aks",
+            "severity": "warning",
+            "title": "Readiness probe failures",
+            "message": "Pod api failed readiness probe 12 times",
+            "resource": "pod/api",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["summary"] == "aks reported warning: Readiness probe failures (pod/api)"
+    assert body["mode"] == "rule_based_stub"
+    assert "next_action" in body
+

--- a/apps/summariser/tests/test_service.py
+++ b/apps/summariser/tests/test_service.py
@@ -1,0 +1,30 @@
+from chatops_guard_summariser.service import summarise_signal
+
+
+def test_summarise_signal_uses_severity_specific_guidance() -> None:
+    result = summarise_signal(
+        {
+            "source": "aks",
+            "severity": "critical",
+            "message": "Node pool is unavailable. Pods cannot be scheduled.",
+            "resource": "nodepool/system",
+        }
+    )
+
+    assert result["summary"] == "aks reported critical: Node pool is unavailable (nodepool/system)"
+    assert "immediately" in result["next_action"]
+    assert result["mode"] == "rule_based_stub"
+
+
+def test_summarise_signal_falls_back_to_info_for_unknown_severity() -> None:
+    result = summarise_signal(
+        {
+            "source": "event-grid",
+            "severity": "unexpected",
+            "message": "Topic received a test event",
+        }
+    )
+
+    assert result["summary"] == "event-grid reported info: Topic received a test event"
+    assert result["impact"] == "Informational signal; no immediate impact is known."
+

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -80,6 +80,8 @@ This file is a grouped planning view of the current backlog after the recent boo
   - [ ] #28 SEC-01 · Trivy image + IaC scan gate
   - [ ] #30 SEC-03 · SBOM generation & upload
   - [ ] #31 CI-01 · Build & push images to ACR
+  - [x] Add the first real image candidate with `apps/summariser`, local Podman build instructions, and CI image scan
+  - [ ] Add ACR Basic plus push workflow only after the summariser image contract is green
   - [ ] #8 Secure ACR Images when they are available
 
 ### Deployment and promotion workflows
@@ -120,6 +122,8 @@ This file is a grouped planning view of the current backlog after the recent boo
 - Dependencies: Event Grid and queue infrastructure, Azure OpenAI access, service runtime decisions
 - Tasks:
   - [ ] #24 SUM-01 · Python FastAPI summariser
+  - [x] Add minimal FastAPI summariser skeleton with `/healthz` and `/summarise`
+  - [x] Keep the first summariser rule-based so Docker/scan/deploy plumbing can be proven before Azure OpenAI cost is introduced
   - [ ] #25 SUM-02 · LangChain prompt w/ Azure OpenAI
   - [ ] #27 API-01 · Event Grid -> Queue -> Summariser
 

--- a/plan.md
+++ b/plan.md
@@ -21,6 +21,7 @@
 - For issue `#52`, the chosen access model is a dedicated Entra admin group, not an individual user object ID. That keeps AKS admin access transferable, reviewable, and easier to explain than binding cluster admin access to one person.
 - Issue `#52` keeps `azure_rbac_enabled = false` in the first managed Entra slice. That is intentional: the smallest useful change is authentication hardening plus disabling local accounts; Azure RBAC role design is a separate authorization rollout.
 - Issue `#16` adds the first Event Grid custom topic in `dev-platform`. The ROI choice is Basic/custom topic, not Event Grid Namespace, because the current application path needs simple event publish/subscribe before MQTT, pull delivery, or higher-throughput namespace features.
+- Issue `#24` now starts with a minimal FastAPI summariser skeleton under `apps/summariser`. This is the first real application image candidate for the Docker/ACR path, but it stays rule-based until Azure OpenAI, secrets, and event subscriptions are introduced deliberately.
 
 ## CI/CD Flow
 1. `tf-plan-apply` workflow (GitHub Actions) runs in matrix mode over `TF_TARGET_ENVS` (defaults to `["dev","dev-platform"]`) and rejects unsupported environment names before Azure login.
@@ -37,7 +38,8 @@
 7. Dependabot is enabled for GitHub Actions and Terraform provider updates so dependency bumps arrive as reviewable PRs instead of silent drift.
 8. `tf-unit-tests.yaml` now validates the live `dev` root, `dev-platform`, and local modules, and Checkov SARIF now covers both active roots.
 9. `tf-destroy.yaml` provides a guarded manual destroy path for cost-control or teardown scenarios. Destroy defaults to `dev-platform`; destroying `dev` requires an extra bootstrap/state confirmation phrase.
-10. `scripts/local_validate.sh` mirrors the low-cost local checks before push: YAML parsing, `actionlint`, Terraform format/init/validate, and Checkov for the active Terraform roots.
+10. `scripts/local_validate.sh` mirrors the low-cost local checks before push: YAML parsing, `actionlint`, Terraform format/init/validate, Checkov for the active Terraform roots, and summariser unit tests.
+11. `app-summariser.yaml` tests the FastAPI summariser, builds its container image, and scans that local image with Trivy before any ACR push exists.
 
 ## Security Hardening Status (Dev)
 | Control | Status | Notes |

--- a/scripts/local_validate.sh
+++ b/scripts/local_validate.sh
@@ -23,6 +23,7 @@ TF_DATA_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/chatops-guard-tfdata.XXXXXX")"
 need actionlint
 need checkov
 need python3
+need pytest
 need ruby
 need terraform
 
@@ -81,5 +82,8 @@ done
 section "Checkov active Terraform roots"
 checkov -d infra/envs/dev --framework terraform --quiet
 checkov -d infra/envs/dev-platform --framework terraform --quiet
+
+section "Summariser app tests"
+PYTHONPATH=apps/summariser/src pytest apps/summariser/tests
 
 section "Local validation complete"


### PR DESCRIPTION
## Summary

Refs #24.
Refs #31.

This PR adds the first real application image candidate for ChatOps Guard: a minimal FastAPI summariser service. It intentionally stops before ACR creation or image push so we can prove the app/image contract without adding Azure cost.

## What Changed

- Adds `apps/summariser` with a minimal FastAPI service:
  - `GET /healthz`
  - `POST /summarise`
- Adds a Dockerfile using `python:3.13-alpine` after local Trivy showed the Debian slim base had unfixed HIGH findings.
- Adds `Summariser App CI` to test, build, and Trivy-scan the image in GitHub Actions.
- Adds Dependabot tracking for the summariser Python dependencies.
- Extends `scripts/local_validate.sh` to include summariser unit tests.
- Updates README, plan, and TODO docs with the ROI decision: prove app/image first, create ACR later.

## Validation

- `scripts/local_validate.sh`
- Temporary venv full app tests: 4 passed, including FastAPI endpoint tests
- Host Podman build:
  - `flatpak-spawn --host podman build --format docker -t chatops-guard/summariser:local apps/summariser`
- Local container runtime checks:
  - `GET /healthz`
  - `POST /summarise`
- Toolbox Trivy image scan against exported image tar: 0 HIGH/CRITICAL
- `git diff --check`

## Learning / ROI Note

This is the lowest-cost path toward Docker/ACR: first create a real app image and scan it locally/CI. ACR Basic and push automation should come in the next PR only after this image contract is green, because ACR has ongoing cost even when idle.